### PR TITLE
Updaate aws-lc-fips-sys to v0.12.11

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -75,4 +75,4 @@ libc = "0.2.121"
 paste = "1.0.11"
 
 [package.metadata.aws-lc-fips-sys]
-commit-hash = "c166b19e8778b5efa98b6dce5004bfd194e67ab5"
+commit-hash = "533fb66f9ed6467449ea65d1d10e344d3b7c9125"

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "aws-lc-fips-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. This is the FIPS validated version of AWS-LC."
-version = "0.12.10"
-links = "aws_lc_fips_0_12_10"
+version = "0.12.11"
+links = "aws_lc_fips_0_12_11"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols.h
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols.h
@@ -17,7 +17,7 @@
 #define BORINGSSL_PREFIX_SYMBOLS_H	
 
 #ifndef BORINGSSL_PREFIX
-#define BORINGSSL_PREFIX aws_lc_fips_0_12_10
+#define BORINGSSL_PREFIX aws_lc_fips_0_12_11
 #endif // BORINGSSL_PREFIX
 
 

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_asm.h
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_asm.h
@@ -20,7 +20,7 @@
 #define BORINGSSL_PREFIX_SYMBOLS_ASM_H
 
 #ifndef BORINGSSL_PREFIX
-#define BORINGSSL_PREFIX aws_lc_fips_0_12_10
+#define BORINGSSL_PREFIX aws_lc_fips_0_12_11
 #endif // BORINGSSL_PREFIX
 
 // On iOS and macOS, we need to treat assembly symbols differently from other

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_nasm.inc
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_nasm.inc
@@ -17,7 +17,7 @@
 %define BORINGSSL_PREFIX_SYMBOLS_NASM_INC
 
 %ifndef BORINGSSL_PREFIX
-%define BORINGSSL_PREFIX aws_lc_fips_0_12_10
+%define BORINGSSL_PREFIX aws_lc_fips_0_12_11
 %endif ; BORINGSSL_PREFIX
 
 ; 32-bit Windows adds underscores to C functions, while 64-bit Windows does not.

--- a/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -4277,7 +4277,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4285,7 +4285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4293,15 +4293,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4313,7 +4313,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4322,7 +4322,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4333,7 +4333,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4344,7 +4344,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4356,7 +4356,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4366,7 +4366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4376,7 +4376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4387,7 +4387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4934,27 +4934,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4962,29 +4962,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4992,7 +4992,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5000,38 +5000,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5040,18 +5040,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5060,18 +5060,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5080,7 +5080,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5088,11 +5088,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5103,30 +5103,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5165,30 +5165,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5198,15 +5198,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -5334,27 +5334,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5362,11 +5362,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5374,22 +5374,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5398,7 +5398,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5407,35 +5407,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5445,7 +5445,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5505,7 +5505,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5561,19 +5561,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5586,7 +5586,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5600,7 +5600,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5611,29 +5611,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5689,7 +5689,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5700,7 +5700,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5713,7 +5713,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5725,7 +5725,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5734,7 +5734,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5745,7 +5745,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5772,23 +5772,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5796,7 +5796,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5804,7 +5804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5812,7 +5812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5820,15 +5820,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5837,7 +5837,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5845,7 +5845,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5854,67 +5854,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5940,7 +5940,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5948,68 +5948,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6017,7 +6017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6025,7 +6025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6034,11 +6034,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6047,15 +6047,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6063,11 +6063,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6075,22 +6075,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6098,30 +6098,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6129,89 +6129,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6220,34 +6220,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6256,13 +6256,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6271,13 +6271,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6290,7 +6290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6303,7 +6303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6316,7 +6316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6328,7 +6328,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6342,7 +6342,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6355,7 +6355,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6368,7 +6368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6380,23 +6380,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6406,7 +6406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6414,37 +6414,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6456,7 +6456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6826,193 +6826,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7021,15 +7021,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7039,11 +7039,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7051,47 +7051,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7099,11 +7099,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7111,43 +7111,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7156,7 +7156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7166,7 +7166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7175,7 +7175,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7185,7 +7185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7194,7 +7194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7204,7 +7204,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7213,7 +7213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7223,7 +7223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7232,7 +7232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7241,7 +7241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7249,7 +7249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7258,7 +7258,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7267,7 +7267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7276,11 +7276,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7288,7 +7288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7348,15 +7348,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7370,7 +7370,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7378,11 +7378,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7397,7 +7397,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7407,7 +7407,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7418,7 +7418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7428,7 +7428,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7437,7 +7437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7446,7 +7446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7455,7 +7455,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7465,7 +7465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7475,23 +7475,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7500,7 +7500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7509,7 +7509,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7519,7 +7519,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7528,7 +7528,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7538,7 +7538,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7549,7 +7549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7560,15 +7560,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7579,7 +7579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7592,11 +7592,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7604,7 +7604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7612,7 +7612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7760,15 +7760,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7792,15 +7792,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7809,7 +7809,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7817,14 +7817,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7832,7 +7832,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7840,7 +7840,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7848,7 +7848,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7856,14 +7856,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7871,7 +7871,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7879,22 +7879,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7970,54 +7970,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8025,7 +8025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8033,79 +8033,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8113,7 +8113,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8121,7 +8121,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8129,7 +8129,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8137,7 +8137,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8145,7 +8145,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8153,7 +8153,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8161,7 +8161,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8169,7 +8169,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8177,117 +8177,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8295,14 +8295,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8312,7 +8312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8324,7 +8324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8334,7 +8334,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8344,15 +8344,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8360,26 +8360,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8387,23 +8387,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8411,14 +8411,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8426,25 +8426,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8452,7 +8452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8460,14 +8460,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8496,19 +8496,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8516,11 +8516,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8528,54 +8528,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8583,59 +8583,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8643,23 +8643,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -8668,26 +8668,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8695,29 +8695,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -8726,22 +8726,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8749,15 +8749,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8766,15 +8766,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -8783,41 +8783,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8825,11 +8825,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8854,7 +8854,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8864,11 +8864,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8876,11 +8876,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8888,7 +8888,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9222,15 +9222,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9238,19 +9238,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9258,7 +9258,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9266,12 +9266,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9279,14 +9279,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9294,33 +9294,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9328,7 +9328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9336,19 +9336,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9356,7 +9356,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9364,7 +9364,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9374,7 +9374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9384,11 +9384,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9396,33 +9396,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9430,34 +9430,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10067,7 +10067,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10092,19 +10092,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10114,19 +10114,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10136,7 +10136,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10144,11 +10144,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10158,7 +10158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10166,7 +10166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10376,11 +10376,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10388,11 +10388,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10447,19 +10447,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10468,7 +10468,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10529,23 +10529,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10553,82 +10553,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10636,7 +10636,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10644,11 +10644,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10656,7 +10656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10665,7 +10665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10676,22 +10676,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10700,7 +10700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10709,7 +10709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10718,7 +10718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10727,33 +10727,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10761,7 +10761,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10769,7 +10769,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11076,23 +11076,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11100,40 +11100,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11141,15 +11141,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11157,55 +11157,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11213,11 +11213,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11225,7 +11225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11233,11 +11233,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11245,11 +11245,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11260,114 +11260,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11378,7 +11378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11388,7 +11388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11398,7 +11398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11408,7 +11408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11416,7 +11416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11426,7 +11426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11434,7 +11434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11444,7 +11444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11452,47 +11452,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11501,45 +11501,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11552,23 +11552,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11578,7 +11578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11587,7 +11587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11596,7 +11596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11604,7 +11604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11612,7 +11612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11620,7 +11620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11629,118 +11629,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11977,7 +11977,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11987,19 +11987,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12009,15 +12009,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12112,15 +12112,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12128,7 +12128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12136,14 +12136,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12151,7 +12151,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12159,23 +12159,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12183,15 +12183,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12278,11 +12278,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12290,19 +12290,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12310,19 +12310,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12420,11 +12420,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12432,19 +12432,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12452,15 +12452,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12558,11 +12558,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12570,34 +12570,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12605,34 +12605,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12640,7 +12640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12649,7 +12649,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12658,7 +12658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12666,7 +12666,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12674,21 +12674,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12696,7 +12696,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12704,7 +12704,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12712,7 +12712,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12721,7 +12721,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12729,11 +12729,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12760,51 +12760,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12814,70 +12814,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12885,15 +12885,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12902,7 +12902,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12911,7 +12911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12922,7 +12922,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12932,11 +12932,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12947,7 +12947,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13020,15 +13020,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13037,7 +13037,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13048,7 +13048,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13059,7 +13059,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13072,7 +13072,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13084,7 +13084,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13093,7 +13093,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13102,43 +13102,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13146,7 +13146,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13154,7 +13154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13163,7 +13163,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13172,40 +13172,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13214,11 +13214,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13226,7 +13226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13237,19 +13237,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13257,19 +13257,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13284,7 +13284,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13292,14 +13292,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13307,114 +13307,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13422,11 +13422,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13434,7 +13434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13442,7 +13442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13450,7 +13450,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13461,75 +13461,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13537,19 +13537,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13641,19 +13641,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13661,11 +13661,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13673,15 +13673,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13727,43 +13727,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13771,7 +13771,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13780,7 +13780,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13788,7 +13788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13797,7 +13797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13809,11 +13809,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13867,28 +13867,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13897,7 +13897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13907,7 +13907,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13918,7 +13918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13929,7 +13929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13940,47 +13940,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13990,7 +13990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13998,14 +13998,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14013,11 +14013,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14025,11 +14025,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14037,11 +14037,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14049,7 +14049,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14205,19 +14205,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14225,19 +14225,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14245,7 +14245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14255,53 +14255,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14309,7 +14309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14318,7 +14318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14328,7 +14328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14338,7 +14338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14348,7 +14348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14358,7 +14358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14369,7 +14369,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14379,7 +14379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14389,7 +14389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14399,7 +14399,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14409,7 +14409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14418,7 +14418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14426,7 +14426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14437,7 +14437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14446,7 +14446,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14455,7 +14455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14463,11 +14463,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14477,15 +14477,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14539,92 +14539,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14632,7 +14632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14641,15 +14641,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14657,11 +14657,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14669,22 +14669,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14694,7 +14694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14702,7 +14702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14824,11 +14824,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14836,11 +14836,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14848,11 +14848,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14860,14 +14860,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14884,7 +14884,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14893,7 +14893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14904,7 +14904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14915,7 +14915,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14969,23 +14969,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14993,7 +14993,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15001,7 +15001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15009,7 +15009,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15018,19 +15018,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15038,11 +15038,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15052,7 +15052,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15060,83 +15060,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15274,11 +15274,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15287,11 +15287,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15302,11 +15302,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15321,7 +15321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15336,7 +15336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15354,7 +15354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15369,66 +15369,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15439,7 +15439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15447,7 +15447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15456,7 +15456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15464,102 +15464,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15567,40 +15567,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15609,7 +15609,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15618,7 +15618,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15626,7 +15626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15634,7 +15634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15644,7 +15644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15652,7 +15652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15660,7 +15660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15670,7 +15670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15680,7 +15680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15688,7 +15688,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15696,7 +15696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15706,7 +15706,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15714,11 +15714,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15726,7 +15726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15735,7 +15735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15743,11 +15743,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15755,7 +15755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15764,7 +15764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15773,7 +15773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15782,7 +15782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15791,7 +15791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15804,7 +15804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15816,7 +15816,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15831,31 +15831,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15865,11 +15865,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15879,11 +15879,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15893,11 +15893,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15907,11 +15907,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15921,18 +15921,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15940,18 +15940,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15961,7 +15961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15971,102 +15971,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16074,28 +16074,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16103,7 +16103,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16111,7 +16111,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16121,31 +16121,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16159,7 +16159,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16173,15 +16173,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16190,7 +16190,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16198,7 +16198,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16207,22 +16207,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16230,40 +16230,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16271,11 +16271,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16283,11 +16283,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16295,11 +16295,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16307,14 +16307,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16488,7 +16488,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16502,7 +16502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16514,7 +16514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16526,11 +16526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16538,15 +16538,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16633,7 +16633,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16645,27 +16645,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16675,7 +16675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16683,7 +16683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16691,23 +16691,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16716,7 +16716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16892,82 +16892,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16976,18 +16976,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16996,7 +16996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17005,23 +17005,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17037,7 +17037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17055,7 +17055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17068,7 +17068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17081,7 +17081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17094,7 +17094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17104,19 +17104,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17375,7 +17375,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17383,7 +17383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17392,7 +17392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17401,22 +17401,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17424,15 +17424,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17519,66 +17519,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17587,7 +17587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17595,7 +17595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17603,7 +17603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17684,7 +17684,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17703,7 +17703,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17711,47 +17711,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18045,51 +18045,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18115,15 +18115,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18131,18 +18131,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18150,79 +18150,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18231,11 +18231,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18244,7 +18244,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18253,12 +18253,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18267,7 +18267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18276,7 +18276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18284,7 +18284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18296,7 +18296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18308,7 +18308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18318,7 +18318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18328,7 +18328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18339,7 +18339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18353,7 +18353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18365,7 +18365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18376,7 +18376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18389,7 +18389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18401,7 +18401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18411,7 +18411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18421,31 +18421,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18456,7 +18456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18467,7 +18467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18480,7 +18480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18491,19 +18491,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18511,19 +18511,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18531,7 +18531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18541,7 +18541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18549,26 +18549,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18577,7 +18577,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18585,11 +18585,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18597,11 +18597,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18611,7 +18611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18621,7 +18621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18632,7 +18632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18640,7 +18640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19141,27 +19141,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19169,51 +19169,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19226,15 +19226,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19242,7 +19242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19250,7 +19250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19258,15 +19258,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19274,68 +19274,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19343,7 +19343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19351,25 +19351,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19377,14 +19377,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19392,7 +19392,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19400,7 +19400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19408,14 +19408,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19437,23 +19437,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19461,23 +19461,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19486,19 +19486,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19506,7 +19506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19514,7 +19514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19522,11 +19522,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19534,55 +19534,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19590,7 +19590,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19598,25 +19598,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19624,19 +19624,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19644,23 +19644,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19668,33 +19668,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19702,22 +19702,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19767,19 +19767,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19787,15 +19787,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19803,15 +19803,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19819,7 +19819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19827,21 +19827,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19850,7 +19850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19862,7 +19862,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19874,7 +19874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19886,19 +19886,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19906,33 +19906,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19941,11 +19941,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19955,7 +19955,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19965,7 +19965,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19975,19 +19975,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19995,18 +19995,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20015,7 +20015,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20024,33 +20024,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20074,11 +20074,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20086,18 +20086,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20105,7 +20105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20113,7 +20113,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20121,21 +20121,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20164,23 +20164,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20188,11 +20188,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20201,7 +20201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20210,15 +20210,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20226,7 +20226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20234,7 +20234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20243,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20252,7 +20252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20261,7 +20261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20270,7 +20270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20279,259 +20279,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20539,11 +20539,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20553,7 +20553,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20561,14 +20561,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20578,7 +20578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20586,42 +20586,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20630,7 +20630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21203,11 +21203,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21215,7 +21215,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21223,54 +21223,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21278,27 +21278,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21306,7 +21306,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21315,44 +21315,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21360,34 +21360,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21395,26 +21395,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21422,18 +21422,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21441,38 +21441,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21480,25 +21480,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21506,7 +21506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21514,23 +21514,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21538,26 +21538,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21565,26 +21565,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21592,7 +21592,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21602,7 +21602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21612,7 +21612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21622,7 +21622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21634,7 +21634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21645,15 +21645,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21661,18 +21661,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21680,7 +21680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21688,28 +21688,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21719,7 +21719,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21729,7 +21729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21739,37 +21739,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21779,66 +21779,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21847,19 +21847,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21868,7 +21868,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21876,7 +21876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21885,7 +21885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21894,15 +21894,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21911,11 +21911,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21924,7 +21924,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21934,7 +21934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21943,7 +21943,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21953,11 +21953,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21965,7 +21965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21973,7 +21973,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21981,21 +21981,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22003,7 +22003,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22012,7 +22012,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22022,11 +22022,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22034,7 +22034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22042,28 +22042,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22073,7 +22073,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22083,7 +22083,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22093,7 +22093,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22103,7 +22103,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22113,7 +22113,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22123,14 +22123,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22139,7 +22139,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22148,34 +22148,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22183,26 +22183,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22213,7 +22213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22223,11 +22223,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22235,19 +22235,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22264,19 +22264,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22363,15 +22363,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22379,14 +22379,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22505,18 +22505,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22524,7 +22524,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22532,202 +22532,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22735,15 +22735,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22752,50 +22752,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22804,7 +22804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22814,7 +22814,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22822,7 +22822,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22830,7 +22830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22838,19 +22838,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22859,11 +22859,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22871,81 +22871,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22954,11 +22954,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22966,7 +22966,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22974,7 +22974,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22986,109 +22986,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23096,7 +23096,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23104,20 +23104,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23125,7 +23125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23133,42 +23133,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23180,14 +23180,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23197,7 +23197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23207,7 +23207,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23217,7 +23217,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23229,7 +23229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23240,7 +23240,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23254,7 +23254,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23263,7 +23263,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23273,7 +23273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23283,7 +23283,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23294,7 +23294,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23308,7 +23308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23317,7 +23317,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23326,11 +23326,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23339,7 +23339,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23348,7 +23348,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23357,15 +23357,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23374,7 +23374,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23383,15 +23383,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23400,7 +23400,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23409,23 +23409,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23434,7 +23434,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23443,15 +23443,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23460,7 +23460,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23469,15 +23469,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23486,7 +23486,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23495,15 +23495,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23512,7 +23512,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23521,21 +23521,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23544,7 +23544,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23553,7 +23553,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23565,7 +23565,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23577,7 +23577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23586,7 +23586,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23595,15 +23595,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23612,7 +23612,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23621,15 +23621,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23638,7 +23638,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23647,7 +23647,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23659,7 +23659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23671,7 +23671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23680,7 +23680,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23689,15 +23689,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23706,7 +23706,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23715,15 +23715,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23732,7 +23732,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23741,7 +23741,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23753,7 +23753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23765,7 +23765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23774,7 +23774,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23783,15 +23783,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23800,7 +23800,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23809,15 +23809,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23826,7 +23826,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23835,7 +23835,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23847,7 +23847,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23859,7 +23859,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23868,7 +23868,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23877,15 +23877,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23897,7 +23897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23909,7 +23909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23921,7 +23921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23933,7 +23933,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23942,7 +23942,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23954,7 +23954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23966,7 +23966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23978,7 +23978,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23987,7 +23987,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23999,7 +23999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24012,7 +24012,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24026,7 +24026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24034,7 +24034,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24042,7 +24042,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24051,11 +24051,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24063,27 +24063,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24093,7 +24093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24101,7 +24101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24116,74 +24116,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24284,19 +24284,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24361,11 +24361,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24452,11 +24452,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24464,42 +24464,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24574,15 +24574,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24595,7 +24595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24610,18 +24610,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24630,14 +24630,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24646,7 +24646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24657,7 +24657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24666,7 +24666,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24678,7 +24678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24690,18 +24690,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24709,14 +24709,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24724,7 +24724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24738,7 +24738,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24753,7 +24753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24766,7 +24766,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24781,7 +24781,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26489,15 +26489,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26505,26 +26505,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26532,14 +26532,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26771,15 +26771,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26787,26 +26787,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26814,26 +26814,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26841,29 +26841,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26871,19 +26871,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26891,18 +26891,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26910,7 +26910,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26918,15 +26918,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26934,26 +26934,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26961,22 +26961,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26984,14 +26984,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26999,7 +26999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27007,14 +27007,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27022,15 +27022,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27038,33 +27038,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27072,26 +27072,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27099,26 +27099,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27126,26 +27126,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27153,26 +27153,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27180,26 +27180,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27207,26 +27207,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27234,26 +27234,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27261,26 +27261,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27288,38 +27288,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27327,26 +27327,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27354,70 +27354,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27428,7 +27428,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27436,7 +27436,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27446,7 +27446,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27544,7 +27544,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27555,11 +27555,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27568,7 +27568,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27577,7 +27577,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27586,7 +27586,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27595,7 +27595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27604,7 +27604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27613,7 +27613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27622,67 +27622,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27691,14 +27691,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27706,7 +27706,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27716,7 +27716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27725,7 +27725,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27734,7 +27734,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27743,7 +27743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27753,11 +27753,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27765,70 +27765,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27846,43 +27846,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27892,7 +27892,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27901,7 +27901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27910,7 +27910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27918,15 +27918,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -27942,15 +27942,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = *mut ::std::os::raw::c_char;

--- a/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto_ssl.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -5229,7 +5229,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5237,7 +5237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5245,15 +5245,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5265,7 +5265,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5274,7 +5274,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5285,7 +5285,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5296,7 +5296,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5308,7 +5308,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5318,7 +5318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5328,7 +5328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5339,7 +5339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5886,27 +5886,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5914,29 +5914,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5944,7 +5944,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5952,38 +5952,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5992,18 +5992,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6012,18 +6012,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6032,7 +6032,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6040,11 +6040,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6055,30 +6055,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -6117,30 +6117,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6150,15 +6150,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6286,27 +6286,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6314,11 +6314,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6326,22 +6326,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6350,7 +6350,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6359,35 +6359,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6397,7 +6397,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6457,7 +6457,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6513,19 +6513,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6538,7 +6538,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6552,7 +6552,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6563,29 +6563,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6641,7 +6641,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6652,7 +6652,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6665,7 +6665,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6677,7 +6677,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6686,7 +6686,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6697,7 +6697,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6724,23 +6724,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6748,7 +6748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6756,7 +6756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6764,7 +6764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6772,15 +6772,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6789,7 +6789,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6797,7 +6797,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6806,67 +6806,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6892,7 +6892,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6900,68 +6900,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6969,7 +6969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6977,7 +6977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6986,11 +6986,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6999,15 +6999,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7015,11 +7015,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7027,22 +7027,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7050,30 +7050,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7081,89 +7081,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7172,34 +7172,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7208,13 +7208,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7223,13 +7223,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7242,7 +7242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7255,7 +7255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7268,7 +7268,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7280,7 +7280,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7294,7 +7294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7307,7 +7307,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7320,7 +7320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7332,23 +7332,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7358,7 +7358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7366,37 +7366,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7408,7 +7408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7778,193 +7778,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7973,15 +7973,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7991,11 +7991,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8003,47 +8003,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8051,11 +8051,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8063,43 +8063,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8108,7 +8108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8118,7 +8118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8127,7 +8127,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8137,7 +8137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8146,7 +8146,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8156,7 +8156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8165,7 +8165,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8175,7 +8175,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8184,7 +8184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8193,7 +8193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8201,7 +8201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8210,7 +8210,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8219,7 +8219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8228,11 +8228,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8240,7 +8240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8300,15 +8300,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8322,7 +8322,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8330,11 +8330,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8349,7 +8349,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8359,7 +8359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8370,7 +8370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8380,7 +8380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8389,7 +8389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8398,7 +8398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8407,7 +8407,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8417,7 +8417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8427,23 +8427,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8452,7 +8452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8461,7 +8461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8471,7 +8471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8480,7 +8480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8490,7 +8490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8501,7 +8501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8512,15 +8512,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8531,7 +8531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8544,11 +8544,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8556,7 +8556,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8564,7 +8564,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8712,15 +8712,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8744,15 +8744,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8761,7 +8761,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8769,14 +8769,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8784,7 +8784,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8792,7 +8792,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8800,7 +8800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8808,14 +8808,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8823,7 +8823,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8831,22 +8831,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8922,54 +8922,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8977,7 +8977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8985,79 +8985,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9065,7 +9065,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9073,7 +9073,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9081,7 +9081,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9089,7 +9089,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9097,7 +9097,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9105,7 +9105,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9113,7 +9113,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9121,7 +9121,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9129,117 +9129,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9247,14 +9247,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9264,7 +9264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9276,7 +9276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9286,7 +9286,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9296,15 +9296,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9312,26 +9312,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9339,23 +9339,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9363,14 +9363,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9378,25 +9378,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9404,7 +9404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9412,14 +9412,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9448,19 +9448,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9468,11 +9468,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9480,54 +9480,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9535,59 +9535,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9595,23 +9595,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9620,26 +9620,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9647,29 +9647,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9678,22 +9678,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9701,15 +9701,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9718,15 +9718,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9735,41 +9735,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9777,11 +9777,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9806,7 +9806,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9816,11 +9816,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9828,11 +9828,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9840,7 +9840,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10174,15 +10174,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10190,19 +10190,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10210,7 +10210,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10218,12 +10218,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10231,14 +10231,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10246,33 +10246,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10280,7 +10280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10288,19 +10288,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10308,7 +10308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10316,7 +10316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10326,7 +10326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10336,11 +10336,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10348,33 +10348,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10382,34 +10382,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11019,7 +11019,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11044,19 +11044,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11066,19 +11066,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11088,7 +11088,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11096,11 +11096,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11110,7 +11110,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11118,7 +11118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11328,11 +11328,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11340,11 +11340,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11399,19 +11399,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11420,7 +11420,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11481,23 +11481,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11505,82 +11505,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11588,7 +11588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11596,11 +11596,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11608,7 +11608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11617,7 +11617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11628,22 +11628,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11652,7 +11652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11661,7 +11661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11670,7 +11670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11679,33 +11679,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11713,7 +11713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11721,7 +11721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12028,23 +12028,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12052,40 +12052,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12093,15 +12093,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12109,55 +12109,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12165,11 +12165,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12177,7 +12177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12185,11 +12185,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12197,11 +12197,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12212,114 +12212,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12330,7 +12330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12340,7 +12340,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12350,7 +12350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12360,7 +12360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12368,7 +12368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12378,7 +12378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12386,7 +12386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12396,7 +12396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12404,47 +12404,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12453,45 +12453,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12504,23 +12504,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12530,7 +12530,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12539,7 +12539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12548,7 +12548,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12556,7 +12556,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12564,7 +12564,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12572,7 +12572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12581,118 +12581,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12929,7 +12929,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12939,19 +12939,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12961,15 +12961,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13064,15 +13064,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13080,7 +13080,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13088,14 +13088,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13103,7 +13103,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13111,23 +13111,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13135,15 +13135,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13230,11 +13230,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13242,19 +13242,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13262,19 +13262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13372,11 +13372,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13384,19 +13384,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13404,15 +13404,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13510,11 +13510,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13522,11 +13522,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 #[repr(C)]
@@ -13571,26 +13571,26 @@ fn bindgen_test_layout_timeval() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13598,34 +13598,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13633,7 +13633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13642,7 +13642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13651,7 +13651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13659,7 +13659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13667,21 +13667,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13689,7 +13689,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13697,7 +13697,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13705,7 +13705,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13714,7 +13714,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13722,11 +13722,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13753,51 +13753,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13807,70 +13807,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13878,15 +13878,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13895,7 +13895,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13904,7 +13904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13915,7 +13915,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13925,11 +13925,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13940,7 +13940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -14013,15 +14013,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14030,7 +14030,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14041,7 +14041,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14052,7 +14052,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14065,7 +14065,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14077,7 +14077,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14086,7 +14086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14095,43 +14095,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14139,7 +14139,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14147,7 +14147,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14156,7 +14156,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14165,40 +14165,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14207,11 +14207,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14219,7 +14219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14230,19 +14230,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14250,19 +14250,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14277,7 +14277,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14285,14 +14285,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14300,114 +14300,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14415,11 +14415,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14427,7 +14427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14435,7 +14435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14443,7 +14443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14454,75 +14454,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14530,19 +14530,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14634,19 +14634,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14654,11 +14654,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14666,15 +14666,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14720,43 +14720,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14764,7 +14764,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14773,7 +14773,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14781,7 +14781,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14790,7 +14790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14802,11 +14802,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14860,28 +14860,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14890,7 +14890,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14900,7 +14900,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14911,7 +14911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14922,7 +14922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14933,47 +14933,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14983,7 +14983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14991,14 +14991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -15006,11 +15006,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15018,11 +15018,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15030,11 +15030,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15042,7 +15042,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15198,19 +15198,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15218,19 +15218,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15238,7 +15238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15248,53 +15248,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15302,7 +15302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15311,7 +15311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15321,7 +15321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15331,7 +15331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15341,7 +15341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15351,7 +15351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15362,7 +15362,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15372,7 +15372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15382,7 +15382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15392,7 +15392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15402,7 +15402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15411,7 +15411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15419,7 +15419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15430,7 +15430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15439,7 +15439,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15448,7 +15448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15456,11 +15456,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15470,15 +15470,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15532,92 +15532,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15625,7 +15625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15634,15 +15634,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15650,11 +15650,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15662,22 +15662,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15687,7 +15687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15695,7 +15695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15817,11 +15817,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15829,11 +15829,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15841,11 +15841,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15853,14 +15853,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15877,7 +15877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15886,7 +15886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15897,7 +15897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15908,7 +15908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15962,23 +15962,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15986,7 +15986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15994,7 +15994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -16002,7 +16002,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -16011,19 +16011,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16031,11 +16031,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16045,7 +16045,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16053,83 +16053,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16267,11 +16267,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16280,11 +16280,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16295,11 +16295,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16314,7 +16314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16329,7 +16329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16347,7 +16347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16362,66 +16362,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16432,7 +16432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16440,7 +16440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16449,7 +16449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16457,102 +16457,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16560,40 +16560,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16602,7 +16602,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16611,7 +16611,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16619,7 +16619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16627,7 +16627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16637,7 +16637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16645,7 +16645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16653,7 +16653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16663,7 +16663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16673,7 +16673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16681,7 +16681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16689,7 +16689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16699,7 +16699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16707,11 +16707,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16719,7 +16719,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16728,7 +16728,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16736,11 +16736,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16748,7 +16748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16757,7 +16757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16766,7 +16766,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16775,7 +16775,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16784,7 +16784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16797,7 +16797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16809,7 +16809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16824,31 +16824,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16858,11 +16858,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16872,11 +16872,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16886,11 +16886,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16900,11 +16900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16914,18 +16914,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16933,18 +16933,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16954,7 +16954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16964,102 +16964,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17067,28 +17067,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17096,7 +17096,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17104,7 +17104,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17114,31 +17114,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17152,7 +17152,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17166,15 +17166,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17183,7 +17183,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17191,7 +17191,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17200,22 +17200,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17223,40 +17223,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17264,11 +17264,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17276,11 +17276,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17288,11 +17288,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17300,14 +17300,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17481,7 +17481,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17495,7 +17495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17507,7 +17507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17519,11 +17519,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17531,15 +17531,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17626,7 +17626,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17638,27 +17638,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17668,7 +17668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17676,7 +17676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17684,23 +17684,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17709,7 +17709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17885,82 +17885,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17969,18 +17969,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17989,7 +17989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17998,23 +17998,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18030,7 +18030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18048,7 +18048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18061,7 +18061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18074,7 +18074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18087,7 +18087,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18097,19 +18097,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18368,7 +18368,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18376,7 +18376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18385,7 +18385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18394,22 +18394,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18417,15 +18417,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18512,66 +18512,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18580,7 +18580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18588,7 +18588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18596,7 +18596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18677,7 +18677,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18696,7 +18696,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18704,47 +18704,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19038,51 +19038,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19108,15 +19108,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19124,18 +19124,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19143,79 +19143,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19224,11 +19224,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19237,7 +19237,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19246,12 +19246,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19260,7 +19260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19269,7 +19269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19289,7 +19289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19301,7 +19301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19311,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19321,7 +19321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19332,7 +19332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19346,7 +19346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19358,7 +19358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19369,7 +19369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19382,7 +19382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19394,7 +19394,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19404,7 +19404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19414,31 +19414,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19449,7 +19449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19460,7 +19460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19473,7 +19473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19484,19 +19484,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19504,19 +19504,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19524,7 +19524,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19534,7 +19534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19542,26 +19542,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19570,7 +19570,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19578,11 +19578,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19590,11 +19590,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19604,7 +19604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19614,7 +19614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19625,7 +19625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19633,7 +19633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20134,27 +20134,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20162,51 +20162,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20219,15 +20219,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20235,7 +20235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20243,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20251,15 +20251,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20267,68 +20267,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20336,7 +20336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20344,25 +20344,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20370,14 +20370,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20385,7 +20385,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20393,7 +20393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20401,14 +20401,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20430,23 +20430,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20454,23 +20454,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20479,19 +20479,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20499,7 +20499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20507,7 +20507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20515,11 +20515,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20527,55 +20527,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20583,7 +20583,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20591,25 +20591,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20617,19 +20617,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20637,23 +20637,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20661,33 +20661,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20695,22 +20695,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20760,19 +20760,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20780,15 +20780,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20796,15 +20796,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20812,7 +20812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20820,21 +20820,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20843,7 +20843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20855,7 +20855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20867,7 +20867,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20879,19 +20879,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20899,33 +20899,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20934,11 +20934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20948,7 +20948,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20958,7 +20958,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20968,19 +20968,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20988,18 +20988,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21008,7 +21008,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21017,33 +21017,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21067,11 +21067,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21079,18 +21079,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21098,7 +21098,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21106,7 +21106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21114,21 +21114,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21157,23 +21157,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21181,11 +21181,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21194,7 +21194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21203,15 +21203,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21219,7 +21219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21227,7 +21227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21236,7 +21236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21245,7 +21245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21254,7 +21254,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21263,7 +21263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21272,259 +21272,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21532,11 +21532,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21546,7 +21546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21554,14 +21554,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21571,7 +21571,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21579,42 +21579,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21623,7 +21623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22196,11 +22196,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22208,7 +22208,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22216,54 +22216,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22271,27 +22271,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22299,7 +22299,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22308,44 +22308,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22353,34 +22353,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22388,26 +22388,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22415,18 +22415,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22434,38 +22434,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22473,25 +22473,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22499,7 +22499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22507,23 +22507,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22531,26 +22531,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22558,26 +22558,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22585,7 +22585,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22595,7 +22595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22605,7 +22605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22615,7 +22615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22627,7 +22627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22638,15 +22638,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22654,18 +22654,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22673,7 +22673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22681,28 +22681,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22712,7 +22712,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22722,7 +22722,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22732,37 +22732,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22772,66 +22772,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22840,19 +22840,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22861,7 +22861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22869,7 +22869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22878,7 +22878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22887,15 +22887,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22904,11 +22904,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22917,7 +22917,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22927,7 +22927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22936,7 +22936,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22946,11 +22946,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22958,7 +22958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22966,7 +22966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22974,21 +22974,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22996,7 +22996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23005,7 +23005,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23015,11 +23015,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23027,7 +23027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23035,28 +23035,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23066,7 +23066,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23076,7 +23076,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23086,7 +23086,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23096,7 +23096,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23106,7 +23106,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23116,14 +23116,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23132,7 +23132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23141,34 +23141,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23176,26 +23176,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23206,7 +23206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23216,11 +23216,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23228,19 +23228,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23257,19 +23257,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23356,15 +23356,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23372,14 +23372,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23498,18 +23498,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23517,7 +23517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23525,202 +23525,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23728,15 +23728,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23745,50 +23745,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23797,7 +23797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23807,7 +23807,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23815,7 +23815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23823,7 +23823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23831,19 +23831,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23852,11 +23852,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23864,81 +23864,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23947,11 +23947,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23959,7 +23959,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23967,7 +23967,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23979,109 +23979,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24089,7 +24089,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24097,20 +24097,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24118,7 +24118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24126,42 +24126,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24173,14 +24173,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24190,7 +24190,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24200,7 +24200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24210,7 +24210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24222,7 +24222,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24233,7 +24233,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24247,7 +24247,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24256,7 +24256,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24266,7 +24266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24276,7 +24276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24287,7 +24287,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24301,7 +24301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24310,7 +24310,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24319,11 +24319,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24332,7 +24332,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24341,7 +24341,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24350,15 +24350,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24367,7 +24367,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24376,15 +24376,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24393,7 +24393,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24402,23 +24402,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24427,7 +24427,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24436,15 +24436,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24453,7 +24453,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24462,15 +24462,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24479,7 +24479,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24488,15 +24488,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24505,7 +24505,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24514,21 +24514,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24537,7 +24537,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24546,7 +24546,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24558,7 +24558,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24570,7 +24570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24579,7 +24579,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24588,15 +24588,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24605,7 +24605,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24614,15 +24614,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24631,7 +24631,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24640,7 +24640,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24652,7 +24652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24664,7 +24664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24673,7 +24673,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24682,15 +24682,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24699,7 +24699,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24708,15 +24708,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24725,7 +24725,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24734,7 +24734,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24746,7 +24746,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24758,7 +24758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24767,7 +24767,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24776,15 +24776,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24793,7 +24793,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24802,15 +24802,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24819,7 +24819,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24828,7 +24828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24840,7 +24840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24852,7 +24852,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24861,7 +24861,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24870,15 +24870,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24890,7 +24890,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24902,7 +24902,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24914,7 +24914,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24926,7 +24926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24935,7 +24935,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24947,7 +24947,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24959,7 +24959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24971,7 +24971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24980,7 +24980,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24992,7 +24992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -25005,7 +25005,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -25019,7 +25019,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -25027,7 +25027,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -25035,7 +25035,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -25044,11 +25044,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25056,27 +25056,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25086,7 +25086,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25094,7 +25094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25109,74 +25109,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25277,19 +25277,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25354,11 +25354,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25445,11 +25445,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25457,42 +25457,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25567,15 +25567,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25588,7 +25588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25603,18 +25603,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25623,14 +25623,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25639,7 +25639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25650,7 +25650,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25659,7 +25659,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25671,7 +25671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25683,18 +25683,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25702,14 +25702,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25717,7 +25717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25731,7 +25731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25746,7 +25746,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25759,7 +25759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25774,7 +25774,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27482,15 +27482,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27498,26 +27498,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27525,14 +27525,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27764,15 +27764,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27780,26 +27780,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27807,26 +27807,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27834,29 +27834,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27864,19 +27864,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27884,18 +27884,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27903,7 +27903,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27911,15 +27911,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27927,26 +27927,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27954,22 +27954,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27977,14 +27977,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27992,7 +27992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -28000,14 +28000,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28015,15 +28015,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28031,33 +28031,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28065,26 +28065,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28092,26 +28092,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28119,26 +28119,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28146,26 +28146,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28173,26 +28173,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28200,26 +28200,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28227,26 +28227,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28254,26 +28254,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28281,38 +28281,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28320,26 +28320,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28347,70 +28347,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28421,7 +28421,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28429,7 +28429,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28439,7 +28439,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28537,7 +28537,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28548,11 +28548,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28561,7 +28561,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28570,7 +28570,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28579,7 +28579,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28588,7 +28588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28597,7 +28597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28606,7 +28606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28615,67 +28615,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28684,14 +28684,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28699,7 +28699,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28709,7 +28709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28718,7 +28718,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28727,7 +28727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28736,7 +28736,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28746,11 +28746,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28758,70 +28758,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28839,43 +28839,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28885,7 +28885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28894,7 +28894,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28903,7 +28903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28911,11 +28911,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28981,119 +28981,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLS_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLS_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLS_with_buffers_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_connect_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_accept_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_is_server"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_is_dtls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_rbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_wbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_rbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_wbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_rfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_wfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_rfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_wfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_do_handshake"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_accept"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29101,7 +29101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_peek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29109,15 +29109,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_has_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29125,220 +29125,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_key_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_error_description"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_mtu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_clear_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_clear_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29351,7 +29351,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29364,71 +29364,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_certs_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_privatekey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29436,7 +29436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29444,7 +29444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29452,7 +29452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29460,26 +29460,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29487,7 +29487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29495,7 +29495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29505,7 +29505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29515,19 +29515,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29535,7 +29535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29543,7 +29543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29552,7 +29552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29561,7 +29561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29569,7 +29569,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29577,7 +29577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29585,7 +29585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29593,7 +29593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29601,7 +29601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_certificate_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29609,7 +29609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29617,7 +29617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29625,29 +29625,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29736,18 +29736,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_private_key_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_can_release_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29772,156 +29772,156 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_ciphersuites"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_ciphersuites"]
     pub fn SSL_set_ciphersuites(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_is_init_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_in_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_in_false_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29929,11 +29929,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_tls_unique"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29942,23 +29942,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_extms_support"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_current_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_session_reused"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_export_keying_material"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29971,7 +29971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29980,7 +29980,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29989,27 +29989,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30017,7 +30017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30025,7 +30025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -30033,29 +30033,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -30063,25 +30063,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30089,7 +30089,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30097,7 +30097,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30105,22 +30105,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30128,19 +30128,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30148,7 +30148,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30156,19 +30156,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30176,34 +30176,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30211,7 +30211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30219,44 +30219,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30265,7 +30265,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30273,7 +30273,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30282,13 +30282,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30302,7 +30302,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30315,11 +30315,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30327,7 +30327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30335,7 +30335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30427,14 +30427,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30442,15 +30442,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30458,7 +30458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30466,29 +30466,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_curves_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_curve_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30496,11 +30496,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30508,7 +30508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_groups"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30516,21 +30516,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_groups_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30543,7 +30543,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30560,7 +30560,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30570,7 +30570,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_custom_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30580,15 +30580,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_verify_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30599,7 +30599,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30610,83 +30610,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30694,19 +30694,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_verify_result"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30719,51 +30719,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30771,7 +30771,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30779,87 +30779,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_client_CA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_dup_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_servername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_servername_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30872,18 +30872,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30891,7 +30891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30899,7 +30899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30916,7 +30916,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30924,11 +30924,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30938,7 +30938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30946,7 +30946,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_has_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30967,7 +30967,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30976,7 +30976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30991,7 +30991,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31008,7 +31008,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -31016,7 +31016,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_select_next_proto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -31027,29 +31027,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31126,29 +31126,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31164,7 +31164,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31180,7 +31180,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31194,7 +31194,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31208,29 +31208,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_psk_identity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31239,7 +31239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31352,22 +31352,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_quic_read_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_quic_write_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_provide_quic_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31376,25 +31376,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quic_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31402,7 +31402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31410,11 +31410,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31422,35 +31422,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_in_early_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_early_data_accepted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31472,21 +31472,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31494,7 +31494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31502,7 +31502,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31510,7 +31510,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31521,19 +31521,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31543,12 +31543,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31556,34 +31556,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ech_accepted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31591,14 +31591,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31608,7 +31608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31616,14 +31616,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31633,7 +31633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31641,14 +31641,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31658,7 +31658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ivs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31667,11 +31667,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_key_block_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_generate_key_block"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31679,26 +31679,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_read_sequence"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_write_sequence"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31708,11 +31708,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31720,7 +31720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31737,11 +31737,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_msg_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31758,11 +31758,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31771,7 +31771,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31779,14 +31779,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31796,46 +31796,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_total_renegotiations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -32029,7 +32029,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -32038,7 +32038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32047,7 +32047,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32056,19 +32056,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32081,7 +32081,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32093,7 +32093,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32106,7 +32106,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32118,77 +32118,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_state_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_client_random"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_server_random"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_description"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32196,11 +32196,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32211,126 +32211,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_get_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLv23_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_2_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_2_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLS_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLS_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLv23_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLv23_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_2_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_2_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLS_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLS_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32343,7 +32343,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32356,98 +32356,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_num_renegotiations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32455,7 +32455,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32467,11 +32467,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32479,61 +32479,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_load_error_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_current_compression"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_current_expansion"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32546,7 +32546,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32559,7 +32559,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32567,7 +32567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32575,25 +32575,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32673,26 +32673,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_cache_hit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_default_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32705,11 +32705,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_want"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32717,7 +32717,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32725,15 +32725,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_type_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_desc_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_state_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32743,42 +32743,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_f_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32786,33 +32786,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get1_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32820,11 +32820,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32836,18 +32836,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -32863,15 +32863,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = *mut ::std::os::raw::c_char;

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -4223,7 +4223,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4231,7 +4231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4239,15 +4239,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4259,7 +4259,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4268,7 +4268,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4279,7 +4279,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4290,7 +4290,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4302,7 +4302,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4312,7 +4312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4322,7 +4322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4333,7 +4333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4919,27 +4919,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4947,29 +4947,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4977,7 +4977,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4985,38 +4985,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5025,18 +5025,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5045,18 +5045,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5065,7 +5065,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5073,11 +5073,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5088,30 +5088,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5150,30 +5150,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5183,15 +5183,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -5319,27 +5319,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5347,11 +5347,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5359,22 +5359,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5383,7 +5383,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5392,35 +5392,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5430,7 +5430,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5490,7 +5490,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5596,19 +5596,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5621,7 +5621,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5635,7 +5635,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5646,29 +5646,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5724,7 +5724,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5735,7 +5735,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5748,7 +5748,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5760,7 +5760,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5769,7 +5769,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5780,7 +5780,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5807,23 +5807,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5831,7 +5831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5839,7 +5839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5847,7 +5847,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5855,15 +5855,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5872,7 +5872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5880,7 +5880,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5889,67 +5889,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5975,7 +5975,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5983,68 +5983,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6052,7 +6052,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6060,7 +6060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6069,11 +6069,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6082,15 +6082,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6098,11 +6098,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6110,22 +6110,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6133,30 +6133,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6164,89 +6164,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6255,34 +6255,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6291,13 +6291,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6306,13 +6306,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6325,7 +6325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6338,7 +6338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6351,7 +6351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6363,7 +6363,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6377,7 +6377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6390,7 +6390,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6403,7 +6403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6415,23 +6415,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6441,7 +6441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6449,37 +6449,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6491,7 +6491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6861,193 +6861,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7056,15 +7056,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7074,11 +7074,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7086,47 +7086,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7134,11 +7134,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7146,43 +7146,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7191,7 +7191,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7201,7 +7201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7210,7 +7210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7220,7 +7220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7229,7 +7229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7239,7 +7239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7248,7 +7248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7258,7 +7258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7267,7 +7267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7276,7 +7276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7284,7 +7284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7293,7 +7293,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7302,7 +7302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7311,11 +7311,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7323,7 +7323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7383,15 +7383,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7405,7 +7405,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7413,11 +7413,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7432,7 +7432,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7442,7 +7442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7453,7 +7453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7463,7 +7463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7472,7 +7472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7481,7 +7481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7490,7 +7490,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7500,7 +7500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7510,23 +7510,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7535,7 +7535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7544,7 +7544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7554,7 +7554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7563,7 +7563,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7573,7 +7573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7584,7 +7584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7595,15 +7595,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7614,7 +7614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7627,11 +7627,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7639,7 +7639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7647,7 +7647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7795,15 +7795,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7827,15 +7827,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7844,7 +7844,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7852,14 +7852,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7867,7 +7867,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7875,7 +7875,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7883,7 +7883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7891,14 +7891,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7906,7 +7906,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7914,22 +7914,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8005,54 +8005,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8060,7 +8060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8068,79 +8068,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8148,7 +8148,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8156,7 +8156,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8164,7 +8164,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8172,7 +8172,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8180,7 +8180,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8188,7 +8188,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8196,7 +8196,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8204,7 +8204,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8212,117 +8212,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8330,14 +8330,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8347,7 +8347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8359,7 +8359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8369,7 +8369,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8379,15 +8379,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8395,26 +8395,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8422,23 +8422,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8446,14 +8446,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8461,25 +8461,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8487,7 +8487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8495,14 +8495,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8531,19 +8531,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8551,11 +8551,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8563,54 +8563,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8618,59 +8618,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8678,23 +8678,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -8703,26 +8703,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8730,29 +8730,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -8761,22 +8761,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8784,15 +8784,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8801,15 +8801,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -8818,41 +8818,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8860,11 +8860,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8889,7 +8889,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8899,11 +8899,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8911,11 +8911,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8923,7 +8923,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9257,15 +9257,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9273,19 +9273,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9293,7 +9293,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9301,12 +9301,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9314,14 +9314,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9329,33 +9329,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9363,7 +9363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9371,19 +9371,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9391,7 +9391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9399,7 +9399,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9409,7 +9409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9419,11 +9419,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9431,33 +9431,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9465,34 +9465,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10102,7 +10102,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10127,19 +10127,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10149,19 +10149,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10171,7 +10171,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10179,11 +10179,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10193,7 +10193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10201,7 +10201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10411,11 +10411,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10423,11 +10423,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10482,19 +10482,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10503,7 +10503,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10564,23 +10564,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10588,82 +10588,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10671,7 +10671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10679,11 +10679,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10691,7 +10691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10700,7 +10700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10711,22 +10711,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10735,7 +10735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10744,7 +10744,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10753,7 +10753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10762,33 +10762,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10796,7 +10796,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10804,7 +10804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11111,23 +11111,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11135,40 +11135,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11176,15 +11176,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11192,55 +11192,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11248,11 +11248,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11260,7 +11260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11268,11 +11268,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11280,11 +11280,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11295,114 +11295,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11413,7 +11413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11423,7 +11423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11433,7 +11433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11443,7 +11443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11451,7 +11451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11461,7 +11461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11469,7 +11469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11479,7 +11479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11487,47 +11487,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11536,45 +11536,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11587,23 +11587,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11613,7 +11613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11622,7 +11622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11631,7 +11631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11639,7 +11639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11647,7 +11647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11655,7 +11655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11664,118 +11664,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12012,7 +12012,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12022,19 +12022,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12044,15 +12044,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12147,15 +12147,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12163,7 +12163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12171,14 +12171,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12186,7 +12186,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12194,23 +12194,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12218,15 +12218,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12313,11 +12313,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12325,19 +12325,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12345,19 +12345,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12455,11 +12455,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12467,19 +12467,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12487,15 +12487,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12593,11 +12593,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12605,34 +12605,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12640,34 +12640,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12675,7 +12675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12684,7 +12684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12693,7 +12693,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12701,7 +12701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12709,21 +12709,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12731,7 +12731,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12739,7 +12739,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12747,7 +12747,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12756,7 +12756,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12764,11 +12764,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12795,51 +12795,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12849,70 +12849,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12920,15 +12920,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12937,7 +12937,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12946,7 +12946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12957,7 +12957,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12967,11 +12967,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12982,7 +12982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13055,15 +13055,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13072,7 +13072,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13083,7 +13083,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13094,7 +13094,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13107,7 +13107,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13119,7 +13119,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13128,7 +13128,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13137,43 +13137,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13181,7 +13181,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13189,7 +13189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13198,7 +13198,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13207,40 +13207,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13249,11 +13249,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13261,7 +13261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13272,19 +13272,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13292,19 +13292,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13319,7 +13319,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13327,14 +13327,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13342,114 +13342,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13457,11 +13457,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13469,7 +13469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13477,7 +13477,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13485,7 +13485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13496,75 +13496,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13572,19 +13572,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13676,19 +13676,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13696,11 +13696,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13708,15 +13708,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13762,43 +13762,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13806,7 +13806,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13815,7 +13815,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13823,7 +13823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13832,7 +13832,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13844,11 +13844,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13902,28 +13902,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13932,7 +13932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13942,7 +13942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13953,7 +13953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13964,7 +13964,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13975,47 +13975,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14025,7 +14025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14033,14 +14033,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14048,11 +14048,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14060,11 +14060,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14072,11 +14072,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14084,7 +14084,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14240,19 +14240,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14260,19 +14260,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14280,7 +14280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14290,53 +14290,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14344,7 +14344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14353,7 +14353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14363,7 +14363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14373,7 +14373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14383,7 +14383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14393,7 +14393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14404,7 +14404,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14414,7 +14414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14424,7 +14424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14434,7 +14434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14444,7 +14444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14453,7 +14453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14461,7 +14461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14472,7 +14472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14481,7 +14481,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14490,7 +14490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14498,11 +14498,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14512,15 +14512,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14574,92 +14574,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14667,7 +14667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14676,15 +14676,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14692,11 +14692,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14704,22 +14704,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14729,7 +14729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14737,7 +14737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14859,11 +14859,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14871,11 +14871,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14883,11 +14883,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14895,14 +14895,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14919,7 +14919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14928,7 +14928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14939,7 +14939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14950,7 +14950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15004,23 +15004,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15028,7 +15028,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15036,7 +15036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15044,7 +15044,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15053,19 +15053,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15073,11 +15073,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15087,7 +15087,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15095,83 +15095,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15309,11 +15309,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15322,11 +15322,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15337,11 +15337,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15356,7 +15356,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15371,7 +15371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15389,7 +15389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15404,66 +15404,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15474,7 +15474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15482,7 +15482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15491,7 +15491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15499,102 +15499,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15602,40 +15602,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15644,7 +15644,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15653,7 +15653,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15661,7 +15661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15669,7 +15669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15679,7 +15679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15687,7 +15687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15695,7 +15695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15705,7 +15705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15715,7 +15715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15723,7 +15723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15731,7 +15731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15741,7 +15741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15749,11 +15749,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15761,7 +15761,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15770,7 +15770,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15778,11 +15778,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15790,7 +15790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15799,7 +15799,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15808,7 +15808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15817,7 +15817,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15826,7 +15826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15839,7 +15839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15851,7 +15851,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15866,31 +15866,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15900,11 +15900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15914,11 +15914,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15928,11 +15928,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15942,11 +15942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15956,18 +15956,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15975,18 +15975,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15996,7 +15996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16006,102 +16006,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16109,28 +16109,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16138,7 +16138,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16146,7 +16146,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16156,31 +16156,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16194,7 +16194,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16208,15 +16208,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16225,7 +16225,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16233,7 +16233,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16242,22 +16242,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16265,40 +16265,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16306,11 +16306,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16318,11 +16318,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16330,11 +16330,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16342,14 +16342,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16523,7 +16523,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16537,7 +16537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16549,7 +16549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16561,11 +16561,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16573,15 +16573,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16668,7 +16668,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16680,27 +16680,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16710,7 +16710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16718,7 +16718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16726,23 +16726,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16751,7 +16751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16927,82 +16927,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17011,18 +17011,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17031,7 +17031,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17040,23 +17040,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17072,7 +17072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17090,7 +17090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17103,7 +17103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17116,7 +17116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17129,7 +17129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17139,19 +17139,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17410,7 +17410,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17418,7 +17418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17427,7 +17427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17436,22 +17436,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17459,15 +17459,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17554,66 +17554,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17622,7 +17622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17630,7 +17630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17638,7 +17638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17719,7 +17719,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17738,7 +17738,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17746,47 +17746,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18080,51 +18080,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18150,15 +18150,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18166,18 +18166,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18185,79 +18185,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18266,11 +18266,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18279,7 +18279,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18288,12 +18288,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18302,7 +18302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18311,7 +18311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18319,7 +18319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18331,7 +18331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18343,7 +18343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18353,7 +18353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18363,7 +18363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18374,7 +18374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18388,7 +18388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18400,7 +18400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18411,7 +18411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18424,7 +18424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18436,7 +18436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18446,7 +18446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18456,31 +18456,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18491,7 +18491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18502,7 +18502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18515,7 +18515,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18526,19 +18526,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18546,19 +18546,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18566,7 +18566,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18576,7 +18576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18584,26 +18584,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18612,7 +18612,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18620,11 +18620,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18632,11 +18632,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18646,7 +18646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18656,7 +18656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18667,7 +18667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18675,7 +18675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19176,27 +19176,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19204,51 +19204,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19261,15 +19261,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19285,7 +19285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19293,15 +19293,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19309,68 +19309,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19378,7 +19378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19386,25 +19386,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19412,14 +19412,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19427,7 +19427,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19435,7 +19435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19443,14 +19443,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19472,23 +19472,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19496,23 +19496,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19521,19 +19521,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19541,7 +19541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19549,7 +19549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19557,11 +19557,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19569,55 +19569,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19625,7 +19625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19633,25 +19633,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19659,19 +19659,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19679,23 +19679,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19703,33 +19703,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19737,22 +19737,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19802,19 +19802,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19822,15 +19822,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19838,15 +19838,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19854,7 +19854,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19862,21 +19862,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19885,7 +19885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19897,7 +19897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19909,7 +19909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19921,19 +19921,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19941,33 +19941,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19976,11 +19976,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19990,7 +19990,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20000,7 +20000,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20010,19 +20010,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20030,18 +20030,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20050,7 +20050,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20059,33 +20059,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20109,11 +20109,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20121,18 +20121,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20140,7 +20140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20148,7 +20148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20156,21 +20156,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20199,23 +20199,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20223,11 +20223,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20236,7 +20236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20245,15 +20245,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20261,7 +20261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20269,7 +20269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20278,7 +20278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20287,7 +20287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20296,7 +20296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20305,7 +20305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20314,259 +20314,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20574,11 +20574,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20588,7 +20588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20596,14 +20596,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20613,7 +20613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20621,42 +20621,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20665,7 +20665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21238,11 +21238,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21250,7 +21250,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21258,54 +21258,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21313,27 +21313,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21341,7 +21341,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21350,44 +21350,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21395,34 +21395,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21430,26 +21430,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21457,18 +21457,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21476,38 +21476,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21515,25 +21515,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21541,7 +21541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21549,23 +21549,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21573,26 +21573,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21600,26 +21600,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21627,7 +21627,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21637,7 +21637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21647,7 +21647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21657,7 +21657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21669,7 +21669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21680,15 +21680,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21696,18 +21696,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21715,7 +21715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21723,28 +21723,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21754,7 +21754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21764,7 +21764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21774,37 +21774,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21814,66 +21814,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21882,19 +21882,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21903,7 +21903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21911,7 +21911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21920,7 +21920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21929,15 +21929,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21946,11 +21946,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21959,7 +21959,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21969,7 +21969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21978,7 +21978,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21988,11 +21988,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22000,7 +22000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22008,7 +22008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22016,21 +22016,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22038,7 +22038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22047,7 +22047,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22057,11 +22057,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22069,7 +22069,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22077,28 +22077,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22108,7 +22108,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22118,7 +22118,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22128,7 +22128,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22138,7 +22138,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22148,7 +22148,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22158,14 +22158,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22174,7 +22174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22183,34 +22183,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22218,26 +22218,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22248,7 +22248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22258,11 +22258,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22270,19 +22270,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22299,19 +22299,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22398,15 +22398,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22414,14 +22414,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22540,18 +22540,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22559,7 +22559,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22567,202 +22567,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22770,15 +22770,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22787,50 +22787,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22839,7 +22839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22849,7 +22849,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22857,7 +22857,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22865,7 +22865,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22873,19 +22873,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22894,11 +22894,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22906,81 +22906,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22989,11 +22989,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23001,7 +23001,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23009,7 +23009,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23021,109 +23021,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23131,7 +23131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23139,20 +23139,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23160,7 +23160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23168,42 +23168,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23215,14 +23215,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23232,7 +23232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23242,7 +23242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23252,7 +23252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23264,7 +23264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23275,7 +23275,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23289,7 +23289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23298,7 +23298,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23308,7 +23308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23318,7 +23318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23329,7 +23329,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23343,7 +23343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23352,7 +23352,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23361,11 +23361,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23374,7 +23374,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23383,7 +23383,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23392,15 +23392,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23409,7 +23409,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23418,15 +23418,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23435,7 +23435,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23444,23 +23444,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23469,7 +23469,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23478,15 +23478,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23495,7 +23495,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23504,15 +23504,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23521,7 +23521,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23530,15 +23530,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23547,7 +23547,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23556,21 +23556,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23579,7 +23579,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23588,7 +23588,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23600,7 +23600,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23612,7 +23612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23621,7 +23621,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23630,15 +23630,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23647,7 +23647,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23656,15 +23656,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23673,7 +23673,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23682,7 +23682,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23694,7 +23694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23706,7 +23706,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23715,7 +23715,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23724,15 +23724,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23741,7 +23741,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23750,15 +23750,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23767,7 +23767,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23776,7 +23776,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23788,7 +23788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23800,7 +23800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23809,7 +23809,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23818,15 +23818,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23835,7 +23835,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23844,15 +23844,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23861,7 +23861,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23870,7 +23870,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23882,7 +23882,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23894,7 +23894,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23903,7 +23903,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23912,15 +23912,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23932,7 +23932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23944,7 +23944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23956,7 +23956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23968,7 +23968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23977,7 +23977,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23989,7 +23989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24001,7 +24001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24013,7 +24013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24022,7 +24022,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24034,7 +24034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24047,7 +24047,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24061,7 +24061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24069,7 +24069,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24077,7 +24077,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24086,11 +24086,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24098,27 +24098,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24128,7 +24128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24136,7 +24136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24151,74 +24151,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24319,19 +24319,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24396,11 +24396,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24487,11 +24487,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24499,42 +24499,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24609,15 +24609,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24630,7 +24630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24645,18 +24645,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24665,14 +24665,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24681,7 +24681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24692,7 +24692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24701,7 +24701,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24713,7 +24713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24725,18 +24725,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24744,14 +24744,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24759,7 +24759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24773,7 +24773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24788,7 +24788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24801,7 +24801,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24816,7 +24816,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26524,15 +26524,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26540,26 +26540,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26567,14 +26567,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26806,15 +26806,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26822,26 +26822,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26849,26 +26849,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26876,29 +26876,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26906,19 +26906,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26926,18 +26926,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26945,7 +26945,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26953,15 +26953,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26969,26 +26969,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26996,22 +26996,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27019,14 +27019,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27034,7 +27034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27042,14 +27042,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27057,15 +27057,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27073,33 +27073,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27107,26 +27107,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27134,26 +27134,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27161,26 +27161,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27188,26 +27188,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27215,26 +27215,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27242,26 +27242,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27269,26 +27269,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27296,26 +27296,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27323,38 +27323,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27362,26 +27362,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27389,70 +27389,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27463,7 +27463,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27471,7 +27471,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27481,7 +27481,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27579,7 +27579,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27590,11 +27590,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27603,7 +27603,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27612,7 +27612,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27621,7 +27621,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27630,7 +27630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27639,7 +27639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27648,7 +27648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27657,67 +27657,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27726,14 +27726,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27741,7 +27741,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27751,7 +27751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27760,7 +27760,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27769,7 +27769,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27778,7 +27778,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27788,11 +27788,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27800,70 +27800,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27881,43 +27881,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27927,7 +27927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27936,7 +27936,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27945,7 +27945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27953,15 +27953,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -27977,15 +27977,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto_ssl.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -5215,7 +5215,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5223,7 +5223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5231,15 +5231,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5251,7 +5251,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5260,7 +5260,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5271,7 +5271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5282,7 +5282,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5294,7 +5294,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5304,7 +5304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5314,7 +5314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5325,7 +5325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5911,27 +5911,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5939,29 +5939,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5969,7 +5969,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5977,38 +5977,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6017,18 +6017,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6037,18 +6037,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6057,7 +6057,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6065,11 +6065,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6080,30 +6080,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -6142,30 +6142,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6175,15 +6175,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6311,27 +6311,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6339,11 +6339,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6351,22 +6351,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6375,7 +6375,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6384,35 +6384,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6422,7 +6422,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6482,7 +6482,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6588,19 +6588,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6613,7 +6613,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6627,7 +6627,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6638,29 +6638,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6716,7 +6716,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6727,7 +6727,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6740,7 +6740,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6752,7 +6752,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6761,7 +6761,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6772,7 +6772,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6799,23 +6799,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6823,7 +6823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6831,7 +6831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6839,7 +6839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6847,15 +6847,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6864,7 +6864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6872,7 +6872,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6881,67 +6881,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6967,7 +6967,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6975,68 +6975,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7044,7 +7044,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7052,7 +7052,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7061,11 +7061,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7074,15 +7074,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7090,11 +7090,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7102,22 +7102,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7125,30 +7125,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7156,89 +7156,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7247,34 +7247,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7283,13 +7283,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7298,13 +7298,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7317,7 +7317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7330,7 +7330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7343,7 +7343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7355,7 +7355,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7369,7 +7369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7382,7 +7382,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7395,7 +7395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7407,23 +7407,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7433,7 +7433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7441,37 +7441,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7483,7 +7483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7853,193 +7853,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8048,15 +8048,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8066,11 +8066,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8078,47 +8078,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8126,11 +8126,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8138,43 +8138,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8183,7 +8183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8193,7 +8193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8202,7 +8202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8212,7 +8212,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8221,7 +8221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8231,7 +8231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8240,7 +8240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8250,7 +8250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8259,7 +8259,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8268,7 +8268,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8276,7 +8276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8285,7 +8285,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8294,7 +8294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8303,11 +8303,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8315,7 +8315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8375,15 +8375,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8397,7 +8397,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8405,11 +8405,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8424,7 +8424,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8434,7 +8434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8445,7 +8445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8455,7 +8455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8464,7 +8464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8473,7 +8473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8482,7 +8482,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8492,7 +8492,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8502,23 +8502,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8527,7 +8527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8536,7 +8536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8546,7 +8546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8555,7 +8555,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8565,7 +8565,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8576,7 +8576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8587,15 +8587,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8606,7 +8606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8619,11 +8619,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8631,7 +8631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8639,7 +8639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8787,15 +8787,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8819,15 +8819,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8836,7 +8836,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8844,14 +8844,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8859,7 +8859,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8867,7 +8867,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8875,7 +8875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8883,14 +8883,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8898,7 +8898,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8906,22 +8906,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8997,54 +8997,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9052,7 +9052,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9060,79 +9060,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9140,7 +9140,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9148,7 +9148,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9156,7 +9156,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9164,7 +9164,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9172,7 +9172,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9180,7 +9180,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9188,7 +9188,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9196,7 +9196,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9204,117 +9204,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9322,14 +9322,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9339,7 +9339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9351,7 +9351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9361,7 +9361,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9371,15 +9371,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9387,26 +9387,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9414,23 +9414,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9438,14 +9438,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9453,25 +9453,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9479,7 +9479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9487,14 +9487,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9523,19 +9523,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9543,11 +9543,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9555,54 +9555,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9610,59 +9610,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9670,23 +9670,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9695,26 +9695,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9722,29 +9722,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9753,22 +9753,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9776,15 +9776,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9793,15 +9793,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9810,41 +9810,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9852,11 +9852,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9881,7 +9881,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9891,11 +9891,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9903,11 +9903,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9915,7 +9915,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10249,15 +10249,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10265,19 +10265,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10285,7 +10285,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10293,12 +10293,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10306,14 +10306,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10321,33 +10321,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10355,7 +10355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10363,19 +10363,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10383,7 +10383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10391,7 +10391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10401,7 +10401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10411,11 +10411,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10423,33 +10423,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10457,34 +10457,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11094,7 +11094,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11119,19 +11119,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11141,19 +11141,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11163,7 +11163,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11171,11 +11171,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11185,7 +11185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11193,7 +11193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11403,11 +11403,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11415,11 +11415,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11474,19 +11474,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11495,7 +11495,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11556,23 +11556,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11580,82 +11580,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11663,7 +11663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11671,11 +11671,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11683,7 +11683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11692,7 +11692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11703,22 +11703,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11727,7 +11727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11736,7 +11736,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11745,7 +11745,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11754,33 +11754,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11788,7 +11788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11796,7 +11796,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12103,23 +12103,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12127,40 +12127,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12168,15 +12168,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12184,55 +12184,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12240,11 +12240,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12252,7 +12252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12260,11 +12260,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12272,11 +12272,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12287,114 +12287,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12405,7 +12405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12415,7 +12415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12425,7 +12425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12435,7 +12435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12443,7 +12443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12453,7 +12453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12461,7 +12461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12471,7 +12471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12479,47 +12479,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12528,45 +12528,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12579,23 +12579,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12605,7 +12605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12614,7 +12614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12623,7 +12623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12631,7 +12631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12639,7 +12639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12647,7 +12647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12656,118 +12656,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -13004,7 +13004,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13014,19 +13014,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13036,15 +13036,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13139,15 +13139,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13155,7 +13155,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13163,14 +13163,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13178,7 +13178,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13186,23 +13186,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13210,15 +13210,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13305,11 +13305,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13317,19 +13317,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13337,19 +13337,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13447,11 +13447,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13459,19 +13459,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13479,15 +13479,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13585,11 +13585,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13597,34 +13597,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13632,34 +13632,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13667,7 +13667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13676,7 +13676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13685,7 +13685,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13693,7 +13693,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13701,21 +13701,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13723,7 +13723,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13731,7 +13731,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13739,7 +13739,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13748,7 +13748,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13756,11 +13756,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13787,51 +13787,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13841,70 +13841,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13912,15 +13912,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13929,7 +13929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13938,7 +13938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13949,7 +13949,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13959,11 +13959,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13974,7 +13974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -14047,15 +14047,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14064,7 +14064,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14075,7 +14075,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14086,7 +14086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14099,7 +14099,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14111,7 +14111,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14120,7 +14120,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14129,43 +14129,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14173,7 +14173,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14181,7 +14181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14190,7 +14190,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14199,40 +14199,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14241,11 +14241,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14253,7 +14253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14264,19 +14264,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14284,19 +14284,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14311,7 +14311,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14319,14 +14319,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14334,114 +14334,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14449,11 +14449,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14461,7 +14461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14469,7 +14469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14477,7 +14477,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14488,75 +14488,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14564,19 +14564,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14668,19 +14668,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14688,11 +14688,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14700,15 +14700,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14754,43 +14754,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14798,7 +14798,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14807,7 +14807,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14815,7 +14815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14824,7 +14824,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14836,11 +14836,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14894,28 +14894,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14924,7 +14924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14934,7 +14934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14945,7 +14945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14956,7 +14956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14967,47 +14967,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15017,7 +15017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -15025,14 +15025,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -15040,11 +15040,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15052,11 +15052,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15064,11 +15064,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15076,7 +15076,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15232,19 +15232,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15252,19 +15252,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15272,7 +15272,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15282,53 +15282,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15336,7 +15336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15345,7 +15345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15355,7 +15355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15365,7 +15365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15375,7 +15375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15385,7 +15385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15396,7 +15396,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15406,7 +15406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15416,7 +15416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15426,7 +15426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15436,7 +15436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15445,7 +15445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15453,7 +15453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15464,7 +15464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15473,7 +15473,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15482,7 +15482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15490,11 +15490,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15504,15 +15504,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15566,92 +15566,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15659,7 +15659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15668,15 +15668,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15684,11 +15684,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15696,22 +15696,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15721,7 +15721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15729,7 +15729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15851,11 +15851,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15863,11 +15863,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15875,11 +15875,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15887,14 +15887,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15911,7 +15911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15920,7 +15920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15931,7 +15931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15942,7 +15942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15996,23 +15996,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -16020,7 +16020,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -16028,7 +16028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -16036,7 +16036,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -16045,19 +16045,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16065,11 +16065,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16079,7 +16079,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16087,83 +16087,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16301,11 +16301,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16314,11 +16314,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16329,11 +16329,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16348,7 +16348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16363,7 +16363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16381,7 +16381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16396,66 +16396,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16466,7 +16466,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16474,7 +16474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16483,7 +16483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16491,102 +16491,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16594,40 +16594,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16636,7 +16636,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16645,7 +16645,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16653,7 +16653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16661,7 +16661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16671,7 +16671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16679,7 +16679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16687,7 +16687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16697,7 +16697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16707,7 +16707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16715,7 +16715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16723,7 +16723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16733,7 +16733,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16741,11 +16741,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16753,7 +16753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16762,7 +16762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16770,11 +16770,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16782,7 +16782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16791,7 +16791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16800,7 +16800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16809,7 +16809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16818,7 +16818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16831,7 +16831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16843,7 +16843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16858,31 +16858,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16892,11 +16892,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16906,11 +16906,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16920,11 +16920,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16934,11 +16934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16948,18 +16948,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16967,18 +16967,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16988,7 +16988,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16998,102 +16998,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17101,28 +17101,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17130,7 +17130,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17138,7 +17138,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17148,31 +17148,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17186,7 +17186,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17200,15 +17200,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17217,7 +17217,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17225,7 +17225,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17234,22 +17234,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17257,40 +17257,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17298,11 +17298,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17310,11 +17310,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17322,11 +17322,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17334,14 +17334,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17515,7 +17515,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17529,7 +17529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17541,7 +17541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17553,11 +17553,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17565,15 +17565,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17660,7 +17660,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17672,27 +17672,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17702,7 +17702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17710,7 +17710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17718,23 +17718,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17743,7 +17743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17919,82 +17919,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -18003,18 +18003,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -18023,7 +18023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -18032,23 +18032,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18064,7 +18064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18082,7 +18082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18095,7 +18095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18108,7 +18108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18121,7 +18121,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18131,19 +18131,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18402,7 +18402,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18410,7 +18410,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18419,7 +18419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18428,22 +18428,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18451,15 +18451,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18546,66 +18546,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18614,7 +18614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18622,7 +18622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18630,7 +18630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18711,7 +18711,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18730,7 +18730,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18738,47 +18738,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19072,51 +19072,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19142,15 +19142,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19158,18 +19158,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19177,79 +19177,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19258,11 +19258,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19271,7 +19271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19280,12 +19280,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19294,7 +19294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19303,7 +19303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19311,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19323,7 +19323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19335,7 +19335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19345,7 +19345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19355,7 +19355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19366,7 +19366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19380,7 +19380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19392,7 +19392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19403,7 +19403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19416,7 +19416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19428,7 +19428,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19438,7 +19438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19448,31 +19448,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19483,7 +19483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19494,7 +19494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19507,7 +19507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19518,19 +19518,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19538,19 +19538,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19558,7 +19558,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19568,7 +19568,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19576,26 +19576,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19604,7 +19604,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19612,11 +19612,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19624,11 +19624,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19638,7 +19638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19648,7 +19648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19659,7 +19659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19667,7 +19667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20168,27 +20168,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20196,51 +20196,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20253,15 +20253,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20269,7 +20269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20277,7 +20277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20285,15 +20285,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20301,68 +20301,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20370,7 +20370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20378,25 +20378,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20404,14 +20404,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20419,7 +20419,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20427,7 +20427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20435,14 +20435,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20464,23 +20464,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20488,23 +20488,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20513,19 +20513,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20533,7 +20533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20541,7 +20541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20549,11 +20549,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20561,55 +20561,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20617,7 +20617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20625,25 +20625,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20651,19 +20651,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20671,23 +20671,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20695,33 +20695,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20729,22 +20729,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20794,19 +20794,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20814,15 +20814,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20830,15 +20830,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20846,7 +20846,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20854,21 +20854,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20877,7 +20877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20889,7 +20889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20901,7 +20901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20913,19 +20913,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20933,33 +20933,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20968,11 +20968,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20982,7 +20982,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20992,7 +20992,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -21002,19 +21002,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -21022,18 +21022,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21042,7 +21042,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21051,33 +21051,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21101,11 +21101,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21113,18 +21113,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21132,7 +21132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21140,7 +21140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21148,21 +21148,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21191,23 +21191,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21215,11 +21215,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21228,7 +21228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21237,15 +21237,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21253,7 +21253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21261,7 +21261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21270,7 +21270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21279,7 +21279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21288,7 +21288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21297,7 +21297,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21306,259 +21306,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21566,11 +21566,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21580,7 +21580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21588,14 +21588,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21605,7 +21605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21613,42 +21613,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21657,7 +21657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22230,11 +22230,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22242,7 +22242,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22250,54 +22250,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22305,27 +22305,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22333,7 +22333,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22342,44 +22342,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22387,34 +22387,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22422,26 +22422,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22449,18 +22449,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22468,38 +22468,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22507,25 +22507,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22533,7 +22533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22541,23 +22541,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22565,26 +22565,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22592,26 +22592,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22619,7 +22619,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22629,7 +22629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22639,7 +22639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22649,7 +22649,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22661,7 +22661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22672,15 +22672,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22688,18 +22688,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22707,7 +22707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22715,28 +22715,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22746,7 +22746,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22756,7 +22756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22766,37 +22766,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22806,66 +22806,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22874,19 +22874,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22895,7 +22895,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22903,7 +22903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22912,7 +22912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22921,15 +22921,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22938,11 +22938,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22951,7 +22951,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22961,7 +22961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22970,7 +22970,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22980,11 +22980,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22992,7 +22992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -23000,7 +23000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -23008,21 +23008,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -23030,7 +23030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23039,7 +23039,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23049,11 +23049,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23061,7 +23061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23069,28 +23069,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23100,7 +23100,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23110,7 +23110,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23120,7 +23120,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23130,7 +23130,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23140,7 +23140,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23150,14 +23150,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23166,7 +23166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23175,34 +23175,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23210,26 +23210,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23240,7 +23240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23250,11 +23250,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23262,19 +23262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23291,19 +23291,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23390,15 +23390,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23406,14 +23406,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23532,18 +23532,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23551,7 +23551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23559,202 +23559,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23762,15 +23762,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23779,50 +23779,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23831,7 +23831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23841,7 +23841,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23849,7 +23849,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23857,7 +23857,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23865,19 +23865,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23886,11 +23886,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23898,81 +23898,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23981,11 +23981,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23993,7 +23993,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -24001,7 +24001,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -24013,109 +24013,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24123,7 +24123,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24131,20 +24131,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24152,7 +24152,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24160,42 +24160,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24207,14 +24207,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24224,7 +24224,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24234,7 +24234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24244,7 +24244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24256,7 +24256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24267,7 +24267,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24281,7 +24281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24290,7 +24290,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24300,7 +24300,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24310,7 +24310,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24321,7 +24321,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24335,7 +24335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24344,7 +24344,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24353,11 +24353,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24366,7 +24366,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24375,7 +24375,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24384,15 +24384,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24401,7 +24401,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24410,15 +24410,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24427,7 +24427,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24436,23 +24436,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24461,7 +24461,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24470,15 +24470,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24487,7 +24487,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24496,15 +24496,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24513,7 +24513,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24522,15 +24522,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24539,7 +24539,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24548,21 +24548,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24571,7 +24571,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24580,7 +24580,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24592,7 +24592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24604,7 +24604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24613,7 +24613,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24622,15 +24622,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24639,7 +24639,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24648,15 +24648,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24665,7 +24665,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24674,7 +24674,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24686,7 +24686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24698,7 +24698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24707,7 +24707,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24716,15 +24716,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24733,7 +24733,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24742,15 +24742,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24759,7 +24759,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24768,7 +24768,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24780,7 +24780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24792,7 +24792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24801,7 +24801,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24810,15 +24810,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24827,7 +24827,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24836,15 +24836,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24853,7 +24853,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24862,7 +24862,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24874,7 +24874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24886,7 +24886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24895,7 +24895,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24904,15 +24904,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24924,7 +24924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24936,7 +24936,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24948,7 +24948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24960,7 +24960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24969,7 +24969,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24981,7 +24981,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24993,7 +24993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -25005,7 +25005,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -25014,7 +25014,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -25026,7 +25026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -25039,7 +25039,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -25053,7 +25053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -25061,7 +25061,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -25069,7 +25069,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -25078,11 +25078,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25090,27 +25090,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25120,7 +25120,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25128,7 +25128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25143,74 +25143,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25311,19 +25311,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25388,11 +25388,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25479,11 +25479,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25491,42 +25491,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25601,15 +25601,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25622,7 +25622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25637,18 +25637,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25657,14 +25657,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25673,7 +25673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25684,7 +25684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25693,7 +25693,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25705,7 +25705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25717,18 +25717,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25736,14 +25736,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25751,7 +25751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25765,7 +25765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25780,7 +25780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25793,7 +25793,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25808,7 +25808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27516,15 +27516,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27532,26 +27532,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27559,14 +27559,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27798,15 +27798,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27814,26 +27814,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27841,26 +27841,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27868,29 +27868,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27898,19 +27898,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27918,18 +27918,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27937,7 +27937,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27945,15 +27945,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27961,26 +27961,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27988,22 +27988,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -28011,14 +28011,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -28026,7 +28026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -28034,14 +28034,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28049,15 +28049,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28065,33 +28065,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28099,26 +28099,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28126,26 +28126,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28153,26 +28153,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28180,26 +28180,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28207,26 +28207,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28234,26 +28234,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28261,26 +28261,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28288,26 +28288,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28315,38 +28315,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28354,26 +28354,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28381,70 +28381,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28455,7 +28455,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28463,7 +28463,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28473,7 +28473,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28571,7 +28571,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28582,11 +28582,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28595,7 +28595,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28604,7 +28604,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28613,7 +28613,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28622,7 +28622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28631,7 +28631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28640,7 +28640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28649,67 +28649,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28718,14 +28718,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28733,7 +28733,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28743,7 +28743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28752,7 +28752,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28761,7 +28761,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28770,7 +28770,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28780,11 +28780,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28792,70 +28792,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28873,43 +28873,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28919,7 +28919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28928,7 +28928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28937,7 +28937,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28945,11 +28945,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -29015,119 +29015,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29135,7 +29135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29143,15 +29143,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29159,220 +29159,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29385,7 +29385,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29398,71 +29398,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29470,7 +29470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29478,7 +29478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29486,7 +29486,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29494,26 +29494,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29521,7 +29521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29529,7 +29529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29539,7 +29539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29549,19 +29549,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29569,7 +29569,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29577,7 +29577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29586,7 +29586,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29595,7 +29595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29603,7 +29603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29611,7 +29611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29619,7 +29619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29627,7 +29627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29635,7 +29635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29643,7 +29643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29651,7 +29651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29659,29 +29659,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29770,18 +29770,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29806,156 +29806,156 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ciphersuites"]
     pub fn SSL_set_ciphersuites(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29963,11 +29963,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29976,23 +29976,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -30005,7 +30005,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -30014,7 +30014,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -30023,27 +30023,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30051,7 +30051,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30059,7 +30059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -30067,29 +30067,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -30097,25 +30097,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30123,7 +30123,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30131,7 +30131,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30139,22 +30139,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30162,19 +30162,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30182,7 +30182,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30190,19 +30190,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30210,34 +30210,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30245,7 +30245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30253,44 +30253,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30299,7 +30299,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30307,7 +30307,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30316,13 +30316,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30336,7 +30336,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30349,11 +30349,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30361,7 +30361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30369,7 +30369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30461,14 +30461,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30476,15 +30476,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30492,7 +30492,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30500,29 +30500,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30530,11 +30530,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30542,7 +30542,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30550,21 +30550,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30577,7 +30577,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30594,7 +30594,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30604,7 +30604,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30614,15 +30614,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30633,7 +30633,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30644,83 +30644,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30728,19 +30728,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30753,51 +30753,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30805,7 +30805,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30813,87 +30813,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30906,18 +30906,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30925,7 +30925,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30933,7 +30933,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30950,7 +30950,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30958,11 +30958,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30972,7 +30972,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30980,7 +30980,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -31001,7 +31001,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -31010,7 +31010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31025,7 +31025,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31042,7 +31042,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -31050,7 +31050,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -31061,29 +31061,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31160,29 +31160,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31198,7 +31198,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31214,7 +31214,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31228,7 +31228,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31242,29 +31242,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31273,7 +31273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31386,22 +31386,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31410,25 +31410,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31436,7 +31436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31444,11 +31444,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31456,35 +31456,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31506,21 +31506,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31528,7 +31528,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31536,7 +31536,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31544,7 +31544,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31555,19 +31555,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31577,12 +31577,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31590,34 +31590,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31625,14 +31625,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31642,7 +31642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31650,14 +31650,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31667,7 +31667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31675,14 +31675,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31692,7 +31692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31701,11 +31701,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31713,26 +31713,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31742,11 +31742,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31754,7 +31754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31771,11 +31771,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31792,11 +31792,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31805,7 +31805,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31813,14 +31813,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31830,46 +31830,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -32063,7 +32063,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -32072,7 +32072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32081,7 +32081,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32090,19 +32090,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32115,7 +32115,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32127,7 +32127,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32140,7 +32140,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32152,77 +32152,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32230,11 +32230,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32245,126 +32245,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32377,7 +32377,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32390,98 +32390,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32489,7 +32489,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32501,11 +32501,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32513,61 +32513,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32580,7 +32580,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32593,7 +32593,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32601,7 +32601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32609,25 +32609,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32707,26 +32707,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32739,11 +32739,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32751,7 +32751,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32759,15 +32759,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32777,42 +32777,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32820,33 +32820,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32854,11 +32854,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32870,18 +32870,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -32897,15 +32897,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -4321,7 +4321,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4329,7 +4329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4337,15 +4337,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4357,7 +4357,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4366,7 +4366,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4377,7 +4377,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4388,7 +4388,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4400,7 +4400,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4410,7 +4410,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4420,7 +4420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4431,7 +4431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4659,27 +4659,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4687,29 +4687,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4717,7 +4717,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4725,38 +4725,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4765,18 +4765,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4785,18 +4785,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4805,7 +4805,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4813,11 +4813,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4828,30 +4828,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4890,30 +4890,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4923,15 +4923,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -5059,27 +5059,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5087,11 +5087,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5099,22 +5099,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5123,7 +5123,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5132,35 +5132,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5170,7 +5170,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5230,7 +5230,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5286,19 +5286,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5311,7 +5311,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5325,7 +5325,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5336,29 +5336,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5414,7 +5414,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5425,7 +5425,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5438,7 +5438,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5450,7 +5450,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5459,7 +5459,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5470,7 +5470,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5497,23 +5497,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5521,7 +5521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5529,7 +5529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5537,7 +5537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5545,15 +5545,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5562,7 +5562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5570,7 +5570,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5579,67 +5579,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5665,7 +5665,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5673,68 +5673,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -5742,7 +5742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -5750,7 +5750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -5759,11 +5759,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -5772,15 +5772,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -5788,11 +5788,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -5800,22 +5800,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -5823,30 +5823,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -5854,89 +5854,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -5945,34 +5945,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -5981,13 +5981,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -5996,13 +5996,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6015,7 +6015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6028,7 +6028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6041,7 +6041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6053,7 +6053,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6067,7 +6067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6080,7 +6080,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6093,7 +6093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6105,23 +6105,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6131,7 +6131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6139,37 +6139,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6181,7 +6181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6551,193 +6551,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6746,15 +6746,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -6764,11 +6764,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -6776,47 +6776,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6824,11 +6824,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6836,43 +6836,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -6881,7 +6881,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6891,7 +6891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6900,7 +6900,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6910,7 +6910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6919,7 +6919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6929,7 +6929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6938,7 +6938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6948,7 +6948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6957,7 +6957,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6966,7 +6966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6974,7 +6974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6983,7 +6983,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -6992,7 +6992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7001,11 +7001,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7013,7 +7013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7073,15 +7073,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7095,7 +7095,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7103,11 +7103,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7122,7 +7122,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7132,7 +7132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7143,7 +7143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7153,7 +7153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7162,7 +7162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7171,7 +7171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7180,7 +7180,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7190,7 +7190,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7200,23 +7200,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7225,7 +7225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7234,7 +7234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7244,7 +7244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7253,7 +7253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7263,7 +7263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7274,7 +7274,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7285,15 +7285,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7304,7 +7304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7317,11 +7317,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7329,7 +7329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7337,7 +7337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7485,15 +7485,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7517,15 +7517,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7534,7 +7534,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7542,14 +7542,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7557,7 +7557,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7565,7 +7565,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7573,7 +7573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7581,14 +7581,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7596,7 +7596,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7604,22 +7604,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7695,54 +7695,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -7750,7 +7750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -7758,79 +7758,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -7838,7 +7838,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -7846,7 +7846,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -7854,7 +7854,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -7862,7 +7862,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -7870,7 +7870,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -7878,7 +7878,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -7886,7 +7886,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -7894,7 +7894,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -7902,117 +7902,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8020,14 +8020,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8037,7 +8037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8049,7 +8049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8059,7 +8059,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8069,15 +8069,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8085,26 +8085,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8112,23 +8112,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8136,14 +8136,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8151,25 +8151,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8177,7 +8177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8185,14 +8185,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8221,19 +8221,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8241,11 +8241,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8253,54 +8253,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8308,59 +8308,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8368,23 +8368,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -8393,26 +8393,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8420,29 +8420,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -8451,22 +8451,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8474,15 +8474,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8491,15 +8491,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -8508,41 +8508,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8550,11 +8550,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8579,7 +8579,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8589,11 +8589,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8601,11 +8601,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8613,7 +8613,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8947,15 +8947,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -8963,19 +8963,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -8983,7 +8983,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -8991,12 +8991,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9004,14 +9004,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9019,33 +9019,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9053,7 +9053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9061,19 +9061,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9081,7 +9081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9089,7 +9089,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9099,7 +9099,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9109,11 +9109,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9121,33 +9121,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9155,34 +9155,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -9792,7 +9792,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9817,19 +9817,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -9839,19 +9839,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9861,7 +9861,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9869,11 +9869,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9883,7 +9883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9891,7 +9891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10101,11 +10101,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10113,11 +10113,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10172,19 +10172,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10193,7 +10193,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10254,23 +10254,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10278,82 +10278,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10361,7 +10361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10369,11 +10369,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10381,7 +10381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10390,7 +10390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10401,22 +10401,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10425,7 +10425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10434,7 +10434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10443,7 +10443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10452,33 +10452,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10486,7 +10486,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10494,7 +10494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -10801,23 +10801,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -10825,40 +10825,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -10866,15 +10866,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -10882,55 +10882,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -10938,11 +10938,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -10950,7 +10950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -10958,11 +10958,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -10970,11 +10970,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -10985,114 +10985,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11103,7 +11103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11113,7 +11113,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11123,7 +11123,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11133,7 +11133,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11141,7 +11141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11151,7 +11151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11159,7 +11159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11169,7 +11169,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11177,47 +11177,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11226,45 +11226,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11277,23 +11277,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11303,7 +11303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11312,7 +11312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11321,7 +11321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11329,7 +11329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11337,7 +11337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11345,7 +11345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11354,118 +11354,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11702,7 +11702,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11712,19 +11712,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -11734,15 +11734,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -11837,15 +11837,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -11853,7 +11853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -11861,14 +11861,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -11876,7 +11876,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -11884,23 +11884,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11908,15 +11908,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12003,11 +12003,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12015,19 +12015,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12035,19 +12035,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12145,11 +12145,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12157,19 +12157,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12177,15 +12177,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12283,11 +12283,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12295,34 +12295,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12330,34 +12330,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12365,7 +12365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12374,7 +12374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12383,7 +12383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12391,7 +12391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12399,21 +12399,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12421,7 +12421,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12429,7 +12429,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12437,7 +12437,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12446,7 +12446,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12454,11 +12454,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12485,51 +12485,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12539,70 +12539,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12610,15 +12610,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12627,7 +12627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12636,7 +12636,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12647,7 +12647,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12657,11 +12657,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12672,7 +12672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -12745,15 +12745,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -12762,7 +12762,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12773,7 +12773,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -12784,7 +12784,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12797,7 +12797,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12809,7 +12809,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -12818,7 +12818,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -12827,43 +12827,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -12871,7 +12871,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -12879,7 +12879,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -12888,7 +12888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -12897,40 +12897,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -12939,11 +12939,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -12951,7 +12951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -12962,19 +12962,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -12982,19 +12982,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13009,7 +13009,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13017,14 +13017,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13032,114 +13032,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13147,11 +13147,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13159,7 +13159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13167,7 +13167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13175,7 +13175,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13186,75 +13186,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13262,19 +13262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13366,19 +13366,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13386,11 +13386,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13398,15 +13398,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13452,43 +13452,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13496,7 +13496,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13505,7 +13505,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13513,7 +13513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13522,7 +13522,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13534,11 +13534,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13592,28 +13592,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13622,7 +13622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13632,7 +13632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13643,7 +13643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13654,7 +13654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13665,47 +13665,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13715,7 +13715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13723,14 +13723,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -13738,11 +13738,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13750,11 +13750,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13762,11 +13762,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13774,7 +13774,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13930,19 +13930,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -13950,19 +13950,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -13970,7 +13970,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -13980,53 +13980,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14034,7 +14034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14043,7 +14043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14053,7 +14053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14063,7 +14063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14073,7 +14073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14083,7 +14083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14094,7 +14094,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14104,7 +14104,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14114,7 +14114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14124,7 +14124,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14134,7 +14134,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14143,7 +14143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14151,7 +14151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14162,7 +14162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14171,7 +14171,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14180,7 +14180,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14188,11 +14188,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14202,15 +14202,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14264,92 +14264,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14357,7 +14357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14366,15 +14366,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14382,11 +14382,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14394,22 +14394,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14419,7 +14419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14427,7 +14427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14549,11 +14549,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14561,11 +14561,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14573,11 +14573,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14585,14 +14585,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14609,7 +14609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14618,7 +14618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14629,7 +14629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14640,7 +14640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14694,23 +14694,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14718,7 +14718,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -14726,7 +14726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -14734,7 +14734,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14743,19 +14743,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -14763,11 +14763,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -14777,7 +14777,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -14785,83 +14785,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -14999,11 +14999,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15012,11 +15012,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15027,11 +15027,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15046,7 +15046,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15061,7 +15061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15079,7 +15079,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15094,66 +15094,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15164,7 +15164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15172,7 +15172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15181,7 +15181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15189,102 +15189,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15292,40 +15292,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15334,7 +15334,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15343,7 +15343,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15351,7 +15351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15359,7 +15359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15369,7 +15369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15377,7 +15377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15385,7 +15385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15395,7 +15395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15405,7 +15405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15413,7 +15413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15421,7 +15421,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15431,7 +15431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15439,11 +15439,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15451,7 +15451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15460,7 +15460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15468,11 +15468,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15480,7 +15480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15489,7 +15489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15498,7 +15498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15507,7 +15507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15516,7 +15516,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15529,7 +15529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15541,7 +15541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15556,31 +15556,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15590,11 +15590,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15604,11 +15604,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15618,11 +15618,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15632,11 +15632,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15646,18 +15646,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15665,18 +15665,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15686,7 +15686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15696,102 +15696,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -15799,28 +15799,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -15828,7 +15828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -15836,7 +15836,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -15846,31 +15846,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -15884,7 +15884,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -15898,15 +15898,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -15915,7 +15915,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -15923,7 +15923,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -15932,22 +15932,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -15955,40 +15955,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -15996,11 +15996,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16008,11 +16008,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16020,11 +16020,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16032,14 +16032,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16213,7 +16213,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16227,7 +16227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16239,7 +16239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16251,11 +16251,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16263,15 +16263,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16358,7 +16358,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16370,27 +16370,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16400,7 +16400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16408,7 +16408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16416,23 +16416,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16441,7 +16441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16617,82 +16617,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16701,18 +16701,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16721,7 +16721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16730,23 +16730,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16762,7 +16762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16780,7 +16780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -16793,7 +16793,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -16806,7 +16806,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -16819,7 +16819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -16829,19 +16829,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17100,7 +17100,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17108,7 +17108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17117,7 +17117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17126,22 +17126,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17149,15 +17149,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17244,66 +17244,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17312,7 +17312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17320,7 +17320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17328,7 +17328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17409,7 +17409,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17428,7 +17428,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17436,47 +17436,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -17770,51 +17770,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -17840,15 +17840,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -17856,18 +17856,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -17875,79 +17875,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -17956,11 +17956,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -17969,7 +17969,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -17978,12 +17978,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -17992,7 +17992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18001,7 +18001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18009,7 +18009,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18021,7 +18021,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18033,7 +18033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18043,7 +18043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18053,7 +18053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18064,7 +18064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18078,7 +18078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18090,7 +18090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18101,7 +18101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18114,7 +18114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18126,7 +18126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18136,7 +18136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18146,31 +18146,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18181,7 +18181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18192,7 +18192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18205,7 +18205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18216,19 +18216,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18236,19 +18236,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18256,7 +18256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18266,7 +18266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18274,26 +18274,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18302,7 +18302,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18310,11 +18310,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18322,11 +18322,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18336,7 +18336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18346,7 +18346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18357,7 +18357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18365,7 +18365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -18866,27 +18866,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -18894,51 +18894,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -18951,15 +18951,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -18967,7 +18967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -18975,7 +18975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -18983,15 +18983,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -18999,68 +18999,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19068,7 +19068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19076,25 +19076,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19102,14 +19102,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19117,7 +19117,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19125,7 +19125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19133,14 +19133,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19162,23 +19162,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19186,23 +19186,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19211,19 +19211,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19231,7 +19231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19239,7 +19239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19247,11 +19247,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19259,55 +19259,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19315,7 +19315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19323,25 +19323,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19349,19 +19349,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19369,23 +19369,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19393,33 +19393,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19427,22 +19427,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19492,19 +19492,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19512,15 +19512,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19528,15 +19528,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19544,7 +19544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19552,21 +19552,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19575,7 +19575,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19587,7 +19587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19599,7 +19599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19611,19 +19611,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19631,33 +19631,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19666,11 +19666,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19680,7 +19680,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19690,7 +19690,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19700,19 +19700,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19720,18 +19720,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19740,7 +19740,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19749,33 +19749,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -19799,11 +19799,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -19811,18 +19811,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19830,7 +19830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19838,7 +19838,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -19846,21 +19846,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -19889,23 +19889,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -19913,11 +19913,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -19926,7 +19926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -19935,15 +19935,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -19951,7 +19951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -19959,7 +19959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -19968,7 +19968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -19977,7 +19977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -19986,7 +19986,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -19995,7 +19995,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20004,259 +20004,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20264,11 +20264,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20278,7 +20278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20286,14 +20286,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20303,7 +20303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20311,42 +20311,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20355,7 +20355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20928,11 +20928,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -20940,7 +20940,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -20948,54 +20948,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21003,27 +21003,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21031,7 +21031,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21040,44 +21040,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21085,34 +21085,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21120,26 +21120,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21147,18 +21147,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21166,38 +21166,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21205,25 +21205,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21231,7 +21231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21239,23 +21239,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21263,26 +21263,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21290,26 +21290,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21317,7 +21317,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21327,7 +21327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21337,7 +21337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21347,7 +21347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21359,7 +21359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21370,15 +21370,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21386,18 +21386,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21405,7 +21405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21413,28 +21413,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21444,7 +21444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21454,7 +21454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21464,37 +21464,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21504,66 +21504,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21572,19 +21572,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21593,7 +21593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21601,7 +21601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21610,7 +21610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21619,15 +21619,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21636,11 +21636,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21649,7 +21649,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21659,7 +21659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21668,7 +21668,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21678,11 +21678,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21690,7 +21690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21698,7 +21698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21706,21 +21706,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -21728,7 +21728,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21737,7 +21737,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21747,11 +21747,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21759,7 +21759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21767,28 +21767,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21798,7 +21798,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21808,7 +21808,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21818,7 +21818,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21828,7 +21828,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21838,7 +21838,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21848,14 +21848,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21864,7 +21864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21873,34 +21873,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21908,26 +21908,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -21938,7 +21938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -21948,11 +21948,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -21960,19 +21960,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -21989,19 +21989,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22088,15 +22088,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22104,14 +22104,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22230,18 +22230,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22249,7 +22249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22257,202 +22257,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22460,15 +22460,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22477,50 +22477,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22529,7 +22529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22539,7 +22539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22547,7 +22547,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22555,7 +22555,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22563,19 +22563,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22584,11 +22584,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22596,81 +22596,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22679,11 +22679,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22691,7 +22691,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22699,7 +22699,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22711,109 +22711,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -22821,7 +22821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -22829,20 +22829,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -22850,7 +22850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -22858,42 +22858,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -22905,14 +22905,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -22922,7 +22922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -22932,7 +22932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -22942,7 +22942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -22954,7 +22954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -22965,7 +22965,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -22979,7 +22979,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -22988,7 +22988,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -22998,7 +22998,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23008,7 +23008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23019,7 +23019,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23033,7 +23033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23042,7 +23042,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23051,11 +23051,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23064,7 +23064,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23073,7 +23073,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23082,15 +23082,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23099,7 +23099,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23108,15 +23108,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23125,7 +23125,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23134,23 +23134,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23159,7 +23159,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23168,15 +23168,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23185,7 +23185,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23194,15 +23194,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23211,7 +23211,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23220,15 +23220,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23237,7 +23237,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23246,21 +23246,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23269,7 +23269,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23278,7 +23278,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23290,7 +23290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23302,7 +23302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23311,7 +23311,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23320,15 +23320,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23337,7 +23337,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23346,15 +23346,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23363,7 +23363,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23372,7 +23372,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23384,7 +23384,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23396,7 +23396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23405,7 +23405,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23414,15 +23414,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23431,7 +23431,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23440,15 +23440,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23457,7 +23457,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23466,7 +23466,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23478,7 +23478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23490,7 +23490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23499,7 +23499,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23508,15 +23508,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23525,7 +23525,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23534,15 +23534,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23551,7 +23551,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23560,7 +23560,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23572,7 +23572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23584,7 +23584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23593,7 +23593,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23602,15 +23602,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23622,7 +23622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23634,7 +23634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23646,7 +23646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23658,7 +23658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23667,7 +23667,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23679,7 +23679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23691,7 +23691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23703,7 +23703,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23712,7 +23712,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23724,7 +23724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -23737,7 +23737,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -23751,7 +23751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -23759,7 +23759,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -23767,7 +23767,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -23776,11 +23776,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -23788,27 +23788,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -23818,7 +23818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -23826,7 +23826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -23841,74 +23841,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24009,19 +24009,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24086,11 +24086,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24177,11 +24177,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24189,42 +24189,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24299,15 +24299,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24320,7 +24320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24335,18 +24335,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24355,14 +24355,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24371,7 +24371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24382,7 +24382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24391,7 +24391,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24403,7 +24403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24415,18 +24415,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24434,14 +24434,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24449,7 +24449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24463,7 +24463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24478,7 +24478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24491,7 +24491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24506,7 +24506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26214,15 +26214,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26230,26 +26230,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26257,14 +26257,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26496,15 +26496,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26512,26 +26512,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26539,26 +26539,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26566,29 +26566,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26596,19 +26596,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26616,18 +26616,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26635,7 +26635,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26643,15 +26643,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26659,26 +26659,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26686,22 +26686,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26709,14 +26709,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26724,7 +26724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -26732,14 +26732,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26747,15 +26747,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26763,33 +26763,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26797,26 +26797,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26824,26 +26824,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26851,26 +26851,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26878,26 +26878,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26905,26 +26905,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26932,26 +26932,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26959,26 +26959,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26986,26 +26986,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27013,38 +27013,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27052,26 +27052,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27079,70 +27079,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27153,7 +27153,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27161,7 +27161,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27171,7 +27171,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27269,7 +27269,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27280,11 +27280,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27293,7 +27293,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27302,7 +27302,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27311,7 +27311,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27320,7 +27320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27329,7 +27329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27338,7 +27338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27347,67 +27347,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27416,14 +27416,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27431,7 +27431,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27441,7 +27441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27450,7 +27450,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27459,7 +27459,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27468,7 +27468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27478,11 +27478,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27490,70 +27490,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27571,43 +27571,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27617,7 +27617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27626,7 +27626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27635,7 +27635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27643,15 +27643,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -27667,15 +27667,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto_ssl.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -5313,7 +5313,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5321,7 +5321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5329,15 +5329,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5349,7 +5349,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5358,7 +5358,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5369,7 +5369,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5380,7 +5380,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5392,7 +5392,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5402,7 +5402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5412,7 +5412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5423,7 +5423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5651,27 +5651,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5679,29 +5679,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5709,7 +5709,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5717,38 +5717,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5757,18 +5757,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5777,18 +5777,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5797,7 +5797,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5805,11 +5805,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5820,30 +5820,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5882,30 +5882,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5915,15 +5915,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6051,27 +6051,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6079,11 +6079,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6091,22 +6091,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6115,7 +6115,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6124,35 +6124,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6162,7 +6162,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6222,7 +6222,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6278,19 +6278,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6303,7 +6303,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6317,7 +6317,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6328,29 +6328,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6406,7 +6406,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6417,7 +6417,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6430,7 +6430,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6442,7 +6442,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6451,7 +6451,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6462,7 +6462,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6489,23 +6489,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6513,7 +6513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6521,7 +6521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6529,7 +6529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6537,15 +6537,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6554,7 +6554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6562,7 +6562,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6571,67 +6571,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6657,7 +6657,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6665,68 +6665,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6734,7 +6734,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6742,7 +6742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6751,11 +6751,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6764,15 +6764,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6780,11 +6780,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6792,22 +6792,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6815,30 +6815,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6846,89 +6846,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6937,34 +6937,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6973,13 +6973,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6988,13 +6988,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7007,7 +7007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7020,7 +7020,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7033,7 +7033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7045,7 +7045,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7059,7 +7059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7072,7 +7072,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7085,7 +7085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7097,23 +7097,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7123,7 +7123,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7131,37 +7131,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7173,7 +7173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7543,193 +7543,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7738,15 +7738,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7756,11 +7756,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7768,47 +7768,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7816,11 +7816,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7828,43 +7828,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7873,7 +7873,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7883,7 +7883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7892,7 +7892,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7902,7 +7902,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7911,7 +7911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7921,7 +7921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7930,7 +7930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7940,7 +7940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7949,7 +7949,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7958,7 +7958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7966,7 +7966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7975,7 +7975,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7984,7 +7984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7993,11 +7993,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8005,7 +8005,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8065,15 +8065,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8087,7 +8087,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8095,11 +8095,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8114,7 +8114,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8124,7 +8124,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8135,7 +8135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8145,7 +8145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8154,7 +8154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8163,7 +8163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8172,7 +8172,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8182,7 +8182,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8192,23 +8192,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8217,7 +8217,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8226,7 +8226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8236,7 +8236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8245,7 +8245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8255,7 +8255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8266,7 +8266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8277,15 +8277,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8296,7 +8296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8309,11 +8309,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8321,7 +8321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8329,7 +8329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8477,15 +8477,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8509,15 +8509,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8526,7 +8526,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8534,14 +8534,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8549,7 +8549,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8557,7 +8557,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8565,7 +8565,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8573,14 +8573,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8588,7 +8588,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8596,22 +8596,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8687,54 +8687,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8742,7 +8742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8750,79 +8750,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8830,7 +8830,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8838,7 +8838,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8846,7 +8846,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8854,7 +8854,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8862,7 +8862,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8870,7 +8870,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8878,7 +8878,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8886,7 +8886,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8894,117 +8894,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9012,14 +9012,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9029,7 +9029,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9041,7 +9041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9051,7 +9051,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9061,15 +9061,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9077,26 +9077,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9104,23 +9104,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9128,14 +9128,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9143,25 +9143,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9169,7 +9169,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9177,14 +9177,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9213,19 +9213,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9233,11 +9233,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9245,54 +9245,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9300,59 +9300,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9360,23 +9360,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9385,26 +9385,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9412,29 +9412,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9443,22 +9443,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9466,15 +9466,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9483,15 +9483,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9500,41 +9500,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9542,11 +9542,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9571,7 +9571,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9581,11 +9581,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9593,11 +9593,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9605,7 +9605,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9939,15 +9939,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9955,19 +9955,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9975,7 +9975,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9983,12 +9983,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9996,14 +9996,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10011,33 +10011,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10045,7 +10045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10053,19 +10053,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10073,7 +10073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10081,7 +10081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10091,7 +10091,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10101,11 +10101,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10113,33 +10113,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10147,34 +10147,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10784,7 +10784,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10809,19 +10809,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10831,19 +10831,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10853,7 +10853,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10861,11 +10861,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10875,7 +10875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10883,7 +10883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11093,11 +11093,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11105,11 +11105,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11164,19 +11164,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11185,7 +11185,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11246,23 +11246,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11270,82 +11270,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11353,7 +11353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11361,11 +11361,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11373,7 +11373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11382,7 +11382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11393,22 +11393,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11417,7 +11417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11426,7 +11426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11435,7 +11435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11444,33 +11444,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11478,7 +11478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11486,7 +11486,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11793,23 +11793,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11817,40 +11817,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11858,15 +11858,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11874,55 +11874,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11930,11 +11930,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11942,7 +11942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11950,11 +11950,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11962,11 +11962,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11977,114 +11977,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12095,7 +12095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12105,7 +12105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12115,7 +12115,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12125,7 +12125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12133,7 +12133,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12143,7 +12143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12151,7 +12151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12161,7 +12161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12169,47 +12169,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12218,45 +12218,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12269,23 +12269,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12295,7 +12295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12304,7 +12304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12313,7 +12313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12321,7 +12321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12329,7 +12329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12337,7 +12337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12346,118 +12346,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12694,7 +12694,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12704,19 +12704,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12726,15 +12726,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12829,15 +12829,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12845,7 +12845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12853,14 +12853,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12868,7 +12868,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12876,23 +12876,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12900,15 +12900,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12995,11 +12995,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13007,19 +13007,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13027,19 +13027,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13137,11 +13137,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13149,19 +13149,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13169,15 +13169,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13275,11 +13275,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13287,34 +13287,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13322,34 +13322,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13357,7 +13357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13366,7 +13366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13375,7 +13375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13383,7 +13383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13391,21 +13391,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13413,7 +13413,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13421,7 +13421,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13429,7 +13429,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13438,7 +13438,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13446,11 +13446,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13477,51 +13477,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13531,70 +13531,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13602,15 +13602,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13619,7 +13619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13628,7 +13628,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13639,7 +13639,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13649,11 +13649,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13664,7 +13664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13737,15 +13737,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13754,7 +13754,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13765,7 +13765,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13776,7 +13776,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13789,7 +13789,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13801,7 +13801,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13810,7 +13810,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13819,43 +13819,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13863,7 +13863,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13871,7 +13871,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13880,7 +13880,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13889,40 +13889,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13931,11 +13931,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13943,7 +13943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13954,19 +13954,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13974,19 +13974,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14001,7 +14001,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14009,14 +14009,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14024,114 +14024,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14139,11 +14139,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14151,7 +14151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14159,7 +14159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14167,7 +14167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14178,75 +14178,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14254,19 +14254,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14358,19 +14358,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14378,11 +14378,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14390,15 +14390,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14444,43 +14444,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14488,7 +14488,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14497,7 +14497,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14505,7 +14505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14514,7 +14514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14526,11 +14526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14584,28 +14584,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14614,7 +14614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14624,7 +14624,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14635,7 +14635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14646,7 +14646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14657,47 +14657,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14707,7 +14707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14715,14 +14715,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14730,11 +14730,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14742,11 +14742,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14754,11 +14754,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14766,7 +14766,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14922,19 +14922,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14942,19 +14942,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14962,7 +14962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14972,53 +14972,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15026,7 +15026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15035,7 +15035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15045,7 +15045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15055,7 +15055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15065,7 +15065,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15075,7 +15075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15086,7 +15086,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15096,7 +15096,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15106,7 +15106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15116,7 +15116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15126,7 +15126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15135,7 +15135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15143,7 +15143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15154,7 +15154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15163,7 +15163,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15172,7 +15172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15180,11 +15180,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15194,15 +15194,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15256,92 +15256,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15349,7 +15349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15358,15 +15358,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15374,11 +15374,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15386,22 +15386,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15411,7 +15411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15419,7 +15419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15541,11 +15541,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15553,11 +15553,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15565,11 +15565,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15577,14 +15577,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15601,7 +15601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15610,7 +15610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15621,7 +15621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15632,7 +15632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15686,23 +15686,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15710,7 +15710,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15718,7 +15718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15726,7 +15726,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15735,19 +15735,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15755,11 +15755,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15769,7 +15769,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15777,83 +15777,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15991,11 +15991,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16004,11 +16004,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16019,11 +16019,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16038,7 +16038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16053,7 +16053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16071,7 +16071,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16086,66 +16086,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16156,7 +16156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16164,7 +16164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16173,7 +16173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16181,102 +16181,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16284,40 +16284,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16326,7 +16326,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16335,7 +16335,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16343,7 +16343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16351,7 +16351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16361,7 +16361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16369,7 +16369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16377,7 +16377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16387,7 +16387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16397,7 +16397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16405,7 +16405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16413,7 +16413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16423,7 +16423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16431,11 +16431,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16443,7 +16443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16452,7 +16452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16460,11 +16460,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16472,7 +16472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16481,7 +16481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16490,7 +16490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16499,7 +16499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16508,7 +16508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16521,7 +16521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16533,7 +16533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16548,31 +16548,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16582,11 +16582,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16596,11 +16596,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16610,11 +16610,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16624,11 +16624,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16638,18 +16638,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16657,18 +16657,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16678,7 +16678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16688,102 +16688,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16791,28 +16791,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16820,7 +16820,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16828,7 +16828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16838,31 +16838,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16876,7 +16876,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16890,15 +16890,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16907,7 +16907,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16915,7 +16915,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16924,22 +16924,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16947,40 +16947,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16988,11 +16988,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17000,11 +17000,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17012,11 +17012,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17024,14 +17024,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17205,7 +17205,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17219,7 +17219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17231,7 +17231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17243,11 +17243,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17255,15 +17255,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17350,7 +17350,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17362,27 +17362,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17392,7 +17392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17400,7 +17400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17408,23 +17408,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17433,7 +17433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17609,82 +17609,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17693,18 +17693,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17713,7 +17713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17722,23 +17722,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17754,7 +17754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17772,7 +17772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17785,7 +17785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17798,7 +17798,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17811,7 +17811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17821,19 +17821,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18092,7 +18092,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18100,7 +18100,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18109,7 +18109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18118,22 +18118,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18141,15 +18141,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18236,66 +18236,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18304,7 +18304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18312,7 +18312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18320,7 +18320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18401,7 +18401,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18420,7 +18420,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18428,47 +18428,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18762,51 +18762,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18832,15 +18832,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18848,18 +18848,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18867,79 +18867,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18948,11 +18948,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18961,7 +18961,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18970,12 +18970,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18984,7 +18984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18993,7 +18993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19001,7 +19001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19013,7 +19013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19025,7 +19025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19035,7 +19035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19045,7 +19045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19056,7 +19056,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19070,7 +19070,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19082,7 +19082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19093,7 +19093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19106,7 +19106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19118,7 +19118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19128,7 +19128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19138,31 +19138,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19173,7 +19173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19184,7 +19184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19197,7 +19197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19208,19 +19208,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19228,19 +19228,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19248,7 +19248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19258,7 +19258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19266,26 +19266,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19294,7 +19294,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19302,11 +19302,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19314,11 +19314,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19328,7 +19328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19338,7 +19338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19349,7 +19349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19357,7 +19357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19858,27 +19858,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19886,51 +19886,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19943,15 +19943,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19959,7 +19959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19967,7 +19967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19975,15 +19975,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19991,68 +19991,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20060,7 +20060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20068,25 +20068,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20094,14 +20094,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20109,7 +20109,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20117,7 +20117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20125,14 +20125,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20154,23 +20154,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20178,23 +20178,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20203,19 +20203,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20223,7 +20223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20231,7 +20231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20239,11 +20239,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20251,55 +20251,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20307,7 +20307,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20315,25 +20315,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20341,19 +20341,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20361,23 +20361,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20385,33 +20385,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20419,22 +20419,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20484,19 +20484,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20504,15 +20504,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20520,15 +20520,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20536,7 +20536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20544,21 +20544,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20567,7 +20567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20579,7 +20579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20591,7 +20591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20603,19 +20603,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20623,33 +20623,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20658,11 +20658,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20672,7 +20672,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20682,7 +20682,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20692,19 +20692,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20712,18 +20712,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20732,7 +20732,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20741,33 +20741,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20791,11 +20791,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20803,18 +20803,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20822,7 +20822,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20830,7 +20830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20838,21 +20838,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20881,23 +20881,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20905,11 +20905,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20918,7 +20918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20927,15 +20927,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20943,7 +20943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20951,7 +20951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20960,7 +20960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20969,7 +20969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20978,7 +20978,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20987,7 +20987,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20996,259 +20996,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21256,11 +21256,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21270,7 +21270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21278,14 +21278,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21295,7 +21295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21303,42 +21303,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21347,7 +21347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21920,11 +21920,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21932,7 +21932,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21940,54 +21940,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21995,27 +21995,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22023,7 +22023,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22032,44 +22032,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22077,34 +22077,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22112,26 +22112,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22139,18 +22139,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22158,38 +22158,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22197,25 +22197,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22223,7 +22223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22231,23 +22231,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22255,26 +22255,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22282,26 +22282,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22309,7 +22309,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22319,7 +22319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22329,7 +22329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22339,7 +22339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22351,7 +22351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22362,15 +22362,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22378,18 +22378,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22397,7 +22397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22405,28 +22405,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22436,7 +22436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22446,7 +22446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22456,37 +22456,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22496,66 +22496,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22564,19 +22564,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22585,7 +22585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22593,7 +22593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22602,7 +22602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22611,15 +22611,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22628,11 +22628,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22641,7 +22641,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22651,7 +22651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22660,7 +22660,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22670,11 +22670,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22682,7 +22682,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22690,7 +22690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22698,21 +22698,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22720,7 +22720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22729,7 +22729,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22739,11 +22739,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22751,7 +22751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22759,28 +22759,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22790,7 +22790,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22800,7 +22800,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22810,7 +22810,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22820,7 +22820,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22830,7 +22830,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22840,14 +22840,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22856,7 +22856,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22865,34 +22865,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22900,26 +22900,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22930,7 +22930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22940,11 +22940,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22952,19 +22952,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22981,19 +22981,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23080,15 +23080,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23096,14 +23096,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23222,18 +23222,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23241,7 +23241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23249,202 +23249,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23452,15 +23452,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23469,50 +23469,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23521,7 +23521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23531,7 +23531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23539,7 +23539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23547,7 +23547,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23555,19 +23555,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23576,11 +23576,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23588,81 +23588,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23671,11 +23671,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23683,7 +23683,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23691,7 +23691,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23703,109 +23703,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23813,7 +23813,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23821,20 +23821,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23842,7 +23842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23850,42 +23850,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23897,14 +23897,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23914,7 +23914,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23924,7 +23924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23934,7 +23934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23946,7 +23946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23957,7 +23957,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23971,7 +23971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23980,7 +23980,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23990,7 +23990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24000,7 +24000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24011,7 +24011,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24025,7 +24025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24034,7 +24034,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24043,11 +24043,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24056,7 +24056,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24065,7 +24065,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24074,15 +24074,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24091,7 +24091,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24100,15 +24100,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24117,7 +24117,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24126,23 +24126,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24151,7 +24151,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24160,15 +24160,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24177,7 +24177,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24186,15 +24186,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24203,7 +24203,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24212,15 +24212,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24229,7 +24229,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24238,21 +24238,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24261,7 +24261,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24270,7 +24270,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24282,7 +24282,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24294,7 +24294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24303,7 +24303,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24312,15 +24312,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24329,7 +24329,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24338,15 +24338,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24355,7 +24355,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24364,7 +24364,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24376,7 +24376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24388,7 +24388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24397,7 +24397,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24406,15 +24406,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24423,7 +24423,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24432,15 +24432,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24449,7 +24449,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24458,7 +24458,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24470,7 +24470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24482,7 +24482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24491,7 +24491,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24500,15 +24500,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24517,7 +24517,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24526,15 +24526,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24543,7 +24543,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24552,7 +24552,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24564,7 +24564,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24576,7 +24576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24585,7 +24585,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24594,15 +24594,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24614,7 +24614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24626,7 +24626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24638,7 +24638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24650,7 +24650,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24659,7 +24659,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24671,7 +24671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24683,7 +24683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24695,7 +24695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24704,7 +24704,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24716,7 +24716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24729,7 +24729,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24751,7 +24751,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24759,7 +24759,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24768,11 +24768,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24780,27 +24780,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24810,7 +24810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24818,7 +24818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24833,74 +24833,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25001,19 +25001,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25078,11 +25078,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25169,11 +25169,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25181,42 +25181,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25291,15 +25291,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25312,7 +25312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25327,18 +25327,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25347,14 +25347,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25363,7 +25363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25374,7 +25374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25383,7 +25383,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25395,7 +25395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25407,18 +25407,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25426,14 +25426,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25441,7 +25441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25455,7 +25455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25470,7 +25470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25483,7 +25483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25498,7 +25498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27206,15 +27206,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27222,26 +27222,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27249,14 +27249,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27488,15 +27488,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27504,26 +27504,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27531,26 +27531,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27558,29 +27558,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27588,19 +27588,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27608,18 +27608,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27627,7 +27627,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27635,15 +27635,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27651,26 +27651,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27678,22 +27678,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27701,14 +27701,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27716,7 +27716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27724,14 +27724,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27739,15 +27739,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27755,33 +27755,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27789,26 +27789,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27816,26 +27816,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27843,26 +27843,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27870,26 +27870,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27897,26 +27897,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27924,26 +27924,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27951,26 +27951,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27978,26 +27978,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28005,38 +28005,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28044,26 +28044,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28071,70 +28071,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28145,7 +28145,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28153,7 +28153,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28163,7 +28163,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28261,7 +28261,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28272,11 +28272,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28285,7 +28285,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28294,7 +28294,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28303,7 +28303,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28312,7 +28312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28321,7 +28321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28330,7 +28330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28339,67 +28339,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28408,14 +28408,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28423,7 +28423,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28433,7 +28433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28442,7 +28442,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28451,7 +28451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28460,7 +28460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28470,11 +28470,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28482,70 +28482,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28563,43 +28563,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28609,7 +28609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28618,7 +28618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28627,7 +28627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28635,11 +28635,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28705,119 +28705,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -28825,7 +28825,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -28833,15 +28833,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -28849,220 +28849,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29075,7 +29075,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29088,71 +29088,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29160,7 +29160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29168,7 +29168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29176,7 +29176,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29184,26 +29184,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29211,7 +29211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29219,7 +29219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29229,7 +29229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29239,19 +29239,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29259,7 +29259,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29267,7 +29267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29276,7 +29276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29285,7 +29285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29293,7 +29293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29301,7 +29301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29309,7 +29309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29317,7 +29317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29325,7 +29325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29333,7 +29333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29341,7 +29341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29349,29 +29349,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29460,18 +29460,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29496,156 +29496,156 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ciphersuites"]
     pub fn SSL_set_ciphersuites(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29653,11 +29653,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29666,23 +29666,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29695,7 +29695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29704,7 +29704,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29713,27 +29713,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29741,7 +29741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29749,7 +29749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -29757,29 +29757,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -29787,25 +29787,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -29813,7 +29813,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -29821,7 +29821,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -29829,22 +29829,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -29852,19 +29852,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -29872,7 +29872,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -29880,19 +29880,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -29900,34 +29900,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -29935,7 +29935,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -29943,44 +29943,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -29989,7 +29989,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -29997,7 +29997,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30006,13 +30006,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30026,7 +30026,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30039,11 +30039,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30051,7 +30051,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30059,7 +30059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30151,14 +30151,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30166,15 +30166,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30182,7 +30182,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30190,29 +30190,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30220,11 +30220,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30232,7 +30232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30240,21 +30240,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30267,7 +30267,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30284,7 +30284,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30294,7 +30294,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30304,15 +30304,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30323,7 +30323,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30334,83 +30334,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30418,19 +30418,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30443,51 +30443,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30495,7 +30495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30503,87 +30503,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30596,18 +30596,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30615,7 +30615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30623,7 +30623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30640,7 +30640,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30648,11 +30648,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30662,7 +30662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30670,7 +30670,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30691,7 +30691,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30700,7 +30700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30715,7 +30715,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30732,7 +30732,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30740,7 +30740,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -30751,29 +30751,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -30850,29 +30850,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30888,7 +30888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -30904,7 +30904,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30918,7 +30918,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -30932,29 +30932,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -30963,7 +30963,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31076,22 +31076,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31100,25 +31100,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31126,7 +31126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31134,11 +31134,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31146,35 +31146,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31196,21 +31196,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31218,7 +31218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31226,7 +31226,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31234,7 +31234,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31245,19 +31245,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31267,12 +31267,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31280,34 +31280,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31315,14 +31315,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31332,7 +31332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31340,14 +31340,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31357,7 +31357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31365,14 +31365,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31382,7 +31382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31391,11 +31391,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31403,26 +31403,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31432,11 +31432,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31444,7 +31444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31461,11 +31461,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31482,11 +31482,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31495,7 +31495,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31503,14 +31503,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31520,46 +31520,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -31753,7 +31753,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -31762,7 +31762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31771,7 +31771,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31780,19 +31780,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31805,7 +31805,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -31817,7 +31817,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31830,7 +31830,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -31842,77 +31842,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -31920,11 +31920,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -31935,126 +31935,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32067,7 +32067,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32080,98 +32080,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32179,7 +32179,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32191,11 +32191,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32203,61 +32203,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32270,7 +32270,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32283,7 +32283,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32291,7 +32291,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32299,25 +32299,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32397,26 +32397,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32429,11 +32429,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32441,7 +32441,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32449,15 +32449,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32467,42 +32467,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32510,33 +32510,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32544,11 +32544,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32560,18 +32560,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -32587,15 +32587,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -4277,7 +4277,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4285,7 +4285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4293,15 +4293,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4313,7 +4313,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4322,7 +4322,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4333,7 +4333,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4344,7 +4344,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4356,7 +4356,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4366,7 +4366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4376,7 +4376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4387,7 +4387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4934,27 +4934,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4962,29 +4962,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4992,7 +4992,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5000,38 +5000,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5040,18 +5040,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5060,18 +5060,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5080,7 +5080,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5088,11 +5088,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5103,30 +5103,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5165,30 +5165,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5198,15 +5198,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -5334,27 +5334,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5362,11 +5362,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5374,22 +5374,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5398,7 +5398,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5407,35 +5407,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5445,7 +5445,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5505,7 +5505,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5561,19 +5561,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5586,7 +5586,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5600,7 +5600,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5611,29 +5611,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5689,7 +5689,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5700,7 +5700,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5713,7 +5713,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5725,7 +5725,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5734,7 +5734,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5745,7 +5745,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5772,23 +5772,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5796,7 +5796,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5804,7 +5804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5812,7 +5812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5820,15 +5820,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5837,7 +5837,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5845,7 +5845,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5854,67 +5854,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5940,7 +5940,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5948,68 +5948,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6017,7 +6017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6025,7 +6025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6034,11 +6034,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6047,15 +6047,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6063,11 +6063,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6075,22 +6075,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6098,30 +6098,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6129,89 +6129,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6220,34 +6220,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6256,13 +6256,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6271,13 +6271,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6290,7 +6290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6303,7 +6303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6316,7 +6316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6328,7 +6328,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6342,7 +6342,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6355,7 +6355,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6368,7 +6368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6380,23 +6380,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6406,7 +6406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6414,37 +6414,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6456,7 +6456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6826,193 +6826,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7021,15 +7021,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7039,11 +7039,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7051,47 +7051,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7099,11 +7099,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7111,43 +7111,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7156,7 +7156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7166,7 +7166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7175,7 +7175,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7185,7 +7185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7194,7 +7194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7204,7 +7204,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7213,7 +7213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7223,7 +7223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7232,7 +7232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7241,7 +7241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7249,7 +7249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7258,7 +7258,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7267,7 +7267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7276,11 +7276,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7288,7 +7288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7348,15 +7348,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7370,7 +7370,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7378,11 +7378,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7397,7 +7397,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7407,7 +7407,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7418,7 +7418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7428,7 +7428,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7437,7 +7437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7446,7 +7446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7455,7 +7455,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7465,7 +7465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7475,23 +7475,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7500,7 +7500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7509,7 +7509,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7519,7 +7519,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7528,7 +7528,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7538,7 +7538,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7549,7 +7549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7560,15 +7560,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7579,7 +7579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7592,11 +7592,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7604,7 +7604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7612,7 +7612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7760,15 +7760,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7792,15 +7792,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7809,7 +7809,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7817,14 +7817,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7832,7 +7832,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7840,7 +7840,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7848,7 +7848,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7856,14 +7856,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7871,7 +7871,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7879,22 +7879,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7970,54 +7970,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8025,7 +8025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8033,79 +8033,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8113,7 +8113,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8121,7 +8121,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8129,7 +8129,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8137,7 +8137,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8145,7 +8145,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8153,7 +8153,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8161,7 +8161,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8169,7 +8169,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8177,117 +8177,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8295,14 +8295,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8312,7 +8312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8324,7 +8324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8334,7 +8334,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8344,15 +8344,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8360,26 +8360,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8387,23 +8387,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8411,14 +8411,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8426,25 +8426,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8452,7 +8452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8460,14 +8460,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8496,19 +8496,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8516,11 +8516,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8528,54 +8528,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8583,59 +8583,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8643,23 +8643,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -8668,26 +8668,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8695,29 +8695,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -8726,22 +8726,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8749,15 +8749,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8766,15 +8766,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -8783,41 +8783,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8825,11 +8825,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8854,7 +8854,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8864,11 +8864,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8876,11 +8876,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8888,7 +8888,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9222,15 +9222,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9238,19 +9238,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9258,7 +9258,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9266,12 +9266,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9279,14 +9279,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9294,33 +9294,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9328,7 +9328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9336,19 +9336,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9356,7 +9356,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9364,7 +9364,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9374,7 +9374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9384,11 +9384,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9396,33 +9396,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9430,34 +9430,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10067,7 +10067,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10092,19 +10092,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10114,19 +10114,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10136,7 +10136,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10144,11 +10144,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10158,7 +10158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10166,7 +10166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10376,11 +10376,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10388,11 +10388,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10447,19 +10447,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10468,7 +10468,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10529,23 +10529,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10553,82 +10553,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10636,7 +10636,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10644,11 +10644,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10656,7 +10656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10665,7 +10665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10676,22 +10676,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10700,7 +10700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10709,7 +10709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10718,7 +10718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10727,33 +10727,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10761,7 +10761,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10769,7 +10769,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11076,23 +11076,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11100,40 +11100,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11141,15 +11141,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11157,55 +11157,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11213,11 +11213,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11225,7 +11225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11233,11 +11233,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11245,11 +11245,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11260,114 +11260,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11378,7 +11378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11388,7 +11388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11398,7 +11398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11408,7 +11408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11416,7 +11416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11426,7 +11426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11434,7 +11434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11444,7 +11444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11452,47 +11452,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11501,45 +11501,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11552,23 +11552,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11578,7 +11578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11587,7 +11587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11596,7 +11596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11604,7 +11604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11612,7 +11612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11620,7 +11620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11629,118 +11629,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11977,7 +11977,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11987,19 +11987,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12009,15 +12009,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12112,15 +12112,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12128,7 +12128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12136,14 +12136,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12151,7 +12151,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12159,23 +12159,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12183,15 +12183,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12278,11 +12278,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12290,19 +12290,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12310,19 +12310,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12420,11 +12420,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12432,19 +12432,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12452,15 +12452,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12558,11 +12558,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12570,34 +12570,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12605,34 +12605,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12640,7 +12640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12649,7 +12649,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12658,7 +12658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12666,7 +12666,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12674,21 +12674,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12696,7 +12696,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12704,7 +12704,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12712,7 +12712,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12721,7 +12721,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12729,11 +12729,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12760,51 +12760,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12814,70 +12814,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12885,15 +12885,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12902,7 +12902,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12911,7 +12911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12922,7 +12922,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12932,11 +12932,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12947,7 +12947,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13020,15 +13020,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13037,7 +13037,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13048,7 +13048,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13059,7 +13059,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13072,7 +13072,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13084,7 +13084,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13093,7 +13093,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13102,43 +13102,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13146,7 +13146,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13154,7 +13154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13163,7 +13163,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13172,40 +13172,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13214,11 +13214,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13226,7 +13226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13237,19 +13237,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13257,19 +13257,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13284,7 +13284,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13292,14 +13292,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13307,114 +13307,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13422,11 +13422,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13434,7 +13434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13442,7 +13442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13450,7 +13450,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13461,75 +13461,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13537,19 +13537,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13641,19 +13641,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13661,11 +13661,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13673,15 +13673,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13727,43 +13727,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13771,7 +13771,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13780,7 +13780,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13788,7 +13788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13797,7 +13797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13809,11 +13809,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13867,28 +13867,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13897,7 +13897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13907,7 +13907,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13918,7 +13918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13929,7 +13929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13940,47 +13940,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13990,7 +13990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13998,14 +13998,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14013,11 +14013,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14025,11 +14025,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14037,11 +14037,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14049,7 +14049,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14205,19 +14205,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14225,19 +14225,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14245,7 +14245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14255,53 +14255,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14309,7 +14309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14318,7 +14318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14328,7 +14328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14338,7 +14338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14348,7 +14348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14358,7 +14358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14369,7 +14369,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14379,7 +14379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14389,7 +14389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14399,7 +14399,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14409,7 +14409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14418,7 +14418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14426,7 +14426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14437,7 +14437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14446,7 +14446,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14455,7 +14455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14463,11 +14463,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14477,15 +14477,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14539,92 +14539,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14632,7 +14632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14641,15 +14641,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14657,11 +14657,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14669,22 +14669,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14694,7 +14694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14702,7 +14702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14824,11 +14824,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14836,11 +14836,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14848,11 +14848,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14860,14 +14860,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14884,7 +14884,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14893,7 +14893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14904,7 +14904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14915,7 +14915,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14969,23 +14969,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14993,7 +14993,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15001,7 +15001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15009,7 +15009,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15018,19 +15018,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15038,11 +15038,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15052,7 +15052,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15060,83 +15060,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15274,11 +15274,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15287,11 +15287,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15302,11 +15302,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15321,7 +15321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15336,7 +15336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15354,7 +15354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15369,66 +15369,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15439,7 +15439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15447,7 +15447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15456,7 +15456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15464,102 +15464,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15567,40 +15567,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15609,7 +15609,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15618,7 +15618,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15626,7 +15626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15634,7 +15634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15644,7 +15644,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15652,7 +15652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15660,7 +15660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15670,7 +15670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15680,7 +15680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15688,7 +15688,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15696,7 +15696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15706,7 +15706,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15714,11 +15714,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15726,7 +15726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15735,7 +15735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15743,11 +15743,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15755,7 +15755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15764,7 +15764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15773,7 +15773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15782,7 +15782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15791,7 +15791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15804,7 +15804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15816,7 +15816,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15831,31 +15831,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15865,11 +15865,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15879,11 +15879,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15893,11 +15893,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15907,11 +15907,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15921,18 +15921,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15940,18 +15940,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15961,7 +15961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15971,102 +15971,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16074,28 +16074,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16103,7 +16103,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16111,7 +16111,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16121,31 +16121,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16159,7 +16159,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16173,15 +16173,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16190,7 +16190,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16198,7 +16198,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16207,22 +16207,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16230,40 +16230,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16271,11 +16271,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16283,11 +16283,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16295,11 +16295,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16307,14 +16307,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16488,7 +16488,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16502,7 +16502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16514,7 +16514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16526,11 +16526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16538,15 +16538,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16633,7 +16633,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16645,27 +16645,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16675,7 +16675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16683,7 +16683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16691,23 +16691,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16716,7 +16716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16892,82 +16892,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16976,18 +16976,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16996,7 +16996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17005,23 +17005,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17037,7 +17037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17055,7 +17055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17068,7 +17068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17081,7 +17081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17094,7 +17094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17104,19 +17104,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17375,7 +17375,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17383,7 +17383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17392,7 +17392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17401,22 +17401,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17424,15 +17424,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17519,66 +17519,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17587,7 +17587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17595,7 +17595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17603,7 +17603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17684,7 +17684,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17703,7 +17703,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17711,47 +17711,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18045,51 +18045,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18115,15 +18115,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18131,18 +18131,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18150,79 +18150,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18231,11 +18231,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18244,7 +18244,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18253,12 +18253,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18267,7 +18267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18276,7 +18276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18284,7 +18284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18296,7 +18296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18308,7 +18308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18318,7 +18318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18328,7 +18328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18339,7 +18339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18353,7 +18353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18365,7 +18365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18376,7 +18376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18389,7 +18389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18401,7 +18401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18411,7 +18411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18421,31 +18421,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18456,7 +18456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18467,7 +18467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18480,7 +18480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18491,19 +18491,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18511,19 +18511,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18531,7 +18531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18541,7 +18541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18549,26 +18549,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18577,7 +18577,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18585,11 +18585,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18597,11 +18597,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18611,7 +18611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18621,7 +18621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18632,7 +18632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18640,7 +18640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19141,27 +19141,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19169,51 +19169,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19226,15 +19226,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19242,7 +19242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19250,7 +19250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19258,15 +19258,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19274,68 +19274,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19343,7 +19343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19351,25 +19351,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19377,14 +19377,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19392,7 +19392,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19400,7 +19400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19408,14 +19408,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19437,23 +19437,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19461,23 +19461,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19486,19 +19486,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19506,7 +19506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19514,7 +19514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19522,11 +19522,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19534,55 +19534,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19590,7 +19590,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19598,25 +19598,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19624,19 +19624,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19644,23 +19644,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19668,33 +19668,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19702,22 +19702,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19767,19 +19767,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19787,15 +19787,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19803,15 +19803,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19819,7 +19819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19827,21 +19827,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19850,7 +19850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19862,7 +19862,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19874,7 +19874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19886,19 +19886,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19906,33 +19906,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19941,11 +19941,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19955,7 +19955,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19965,7 +19965,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19975,19 +19975,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19995,18 +19995,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20015,7 +20015,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20024,33 +20024,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20074,11 +20074,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20086,18 +20086,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20105,7 +20105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20113,7 +20113,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20121,21 +20121,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20164,23 +20164,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20188,11 +20188,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20201,7 +20201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20210,15 +20210,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20226,7 +20226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20234,7 +20234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20243,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20252,7 +20252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20261,7 +20261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20270,7 +20270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20279,259 +20279,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20539,11 +20539,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20553,7 +20553,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20561,14 +20561,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20578,7 +20578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20586,42 +20586,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20630,7 +20630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21203,11 +21203,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21215,7 +21215,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21223,54 +21223,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21278,27 +21278,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21306,7 +21306,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21315,44 +21315,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21360,34 +21360,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21395,26 +21395,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21422,18 +21422,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21441,38 +21441,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21480,25 +21480,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21506,7 +21506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21514,23 +21514,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21538,26 +21538,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21565,26 +21565,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21592,7 +21592,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21602,7 +21602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21612,7 +21612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21622,7 +21622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21634,7 +21634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21645,15 +21645,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21661,18 +21661,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21680,7 +21680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21688,28 +21688,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21719,7 +21719,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21729,7 +21729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21739,37 +21739,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21779,66 +21779,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21847,19 +21847,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21868,7 +21868,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21876,7 +21876,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21885,7 +21885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21894,15 +21894,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21911,11 +21911,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21924,7 +21924,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21934,7 +21934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21943,7 +21943,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21953,11 +21953,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21965,7 +21965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21973,7 +21973,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21981,21 +21981,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22003,7 +22003,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22012,7 +22012,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22022,11 +22022,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22034,7 +22034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22042,28 +22042,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22073,7 +22073,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22083,7 +22083,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22093,7 +22093,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22103,7 +22103,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22113,7 +22113,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22123,14 +22123,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22139,7 +22139,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22148,34 +22148,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22183,26 +22183,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22213,7 +22213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22223,11 +22223,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22235,19 +22235,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22264,19 +22264,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22363,15 +22363,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22379,14 +22379,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22505,18 +22505,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22524,7 +22524,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22532,202 +22532,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22735,15 +22735,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22752,50 +22752,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22804,7 +22804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22814,7 +22814,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22822,7 +22822,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22830,7 +22830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22838,19 +22838,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22859,11 +22859,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22871,81 +22871,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22954,11 +22954,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22966,7 +22966,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22974,7 +22974,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22986,109 +22986,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23096,7 +23096,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23104,20 +23104,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23125,7 +23125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23133,42 +23133,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23180,14 +23180,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23197,7 +23197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23207,7 +23207,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23217,7 +23217,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23229,7 +23229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23240,7 +23240,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23254,7 +23254,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23263,7 +23263,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23273,7 +23273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23283,7 +23283,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23294,7 +23294,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23308,7 +23308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23317,7 +23317,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23326,11 +23326,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23339,7 +23339,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23348,7 +23348,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23357,15 +23357,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23374,7 +23374,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23383,15 +23383,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23400,7 +23400,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23409,23 +23409,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23434,7 +23434,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23443,15 +23443,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23460,7 +23460,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23469,15 +23469,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23486,7 +23486,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23495,15 +23495,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23512,7 +23512,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23521,21 +23521,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23544,7 +23544,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23553,7 +23553,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23565,7 +23565,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23577,7 +23577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23586,7 +23586,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23595,15 +23595,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23612,7 +23612,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23621,15 +23621,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23638,7 +23638,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23647,7 +23647,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23659,7 +23659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23671,7 +23671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23680,7 +23680,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23689,15 +23689,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23706,7 +23706,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23715,15 +23715,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23732,7 +23732,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23741,7 +23741,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23753,7 +23753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23765,7 +23765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23774,7 +23774,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23783,15 +23783,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23800,7 +23800,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23809,15 +23809,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23826,7 +23826,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23835,7 +23835,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23847,7 +23847,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23859,7 +23859,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23868,7 +23868,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23877,15 +23877,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23897,7 +23897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23909,7 +23909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23921,7 +23921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23933,7 +23933,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23942,7 +23942,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23954,7 +23954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23966,7 +23966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23978,7 +23978,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23987,7 +23987,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23999,7 +23999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24012,7 +24012,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24026,7 +24026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24034,7 +24034,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24042,7 +24042,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24051,11 +24051,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24063,27 +24063,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24093,7 +24093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24101,7 +24101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24116,74 +24116,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24284,19 +24284,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24361,11 +24361,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24452,11 +24452,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24464,42 +24464,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24574,15 +24574,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24595,7 +24595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24610,18 +24610,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24630,14 +24630,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24646,7 +24646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24657,7 +24657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24666,7 +24666,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24678,7 +24678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24690,18 +24690,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24709,14 +24709,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24724,7 +24724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24738,7 +24738,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24753,7 +24753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24766,7 +24766,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24781,7 +24781,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26489,15 +26489,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26505,26 +26505,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26532,14 +26532,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26771,15 +26771,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26787,26 +26787,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26814,26 +26814,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26841,29 +26841,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26871,19 +26871,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26891,18 +26891,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26910,7 +26910,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26918,15 +26918,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26934,26 +26934,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26961,22 +26961,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26984,14 +26984,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26999,7 +26999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27007,14 +27007,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27022,15 +27022,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27038,33 +27038,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27072,26 +27072,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27099,26 +27099,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27126,26 +27126,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27153,26 +27153,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27180,26 +27180,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27207,26 +27207,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27234,26 +27234,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27261,26 +27261,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27288,38 +27288,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27327,26 +27327,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27354,70 +27354,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27428,7 +27428,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27436,7 +27436,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27446,7 +27446,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27544,7 +27544,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27555,11 +27555,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27568,7 +27568,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27577,7 +27577,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27586,7 +27586,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27595,7 +27595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27604,7 +27604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27613,7 +27613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27622,67 +27622,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27691,14 +27691,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27706,7 +27706,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27716,7 +27716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27725,7 +27725,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27734,7 +27734,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27743,7 +27743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27753,11 +27753,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27765,70 +27765,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27846,43 +27846,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27892,7 +27892,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27901,7 +27901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27910,7 +27910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27918,15 +27918,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -27942,15 +27942,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto_ssl.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -5229,7 +5229,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5237,7 +5237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5245,15 +5245,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5265,7 +5265,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5274,7 +5274,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5285,7 +5285,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5296,7 +5296,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5308,7 +5308,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5318,7 +5318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5328,7 +5328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5339,7 +5339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5886,27 +5886,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5914,29 +5914,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5944,7 +5944,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5952,38 +5952,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5992,18 +5992,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6012,18 +6012,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6032,7 +6032,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6040,11 +6040,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6055,30 +6055,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -6117,30 +6117,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6150,15 +6150,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6286,27 +6286,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6314,11 +6314,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6326,22 +6326,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6350,7 +6350,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6359,35 +6359,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6397,7 +6397,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6457,7 +6457,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6513,19 +6513,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6538,7 +6538,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6552,7 +6552,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6563,29 +6563,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6641,7 +6641,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6652,7 +6652,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6665,7 +6665,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6677,7 +6677,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6686,7 +6686,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6697,7 +6697,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6724,23 +6724,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6748,7 +6748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6756,7 +6756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6764,7 +6764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6772,15 +6772,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6789,7 +6789,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6797,7 +6797,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6806,67 +6806,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6892,7 +6892,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6900,68 +6900,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6969,7 +6969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6977,7 +6977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6986,11 +6986,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6999,15 +6999,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7015,11 +7015,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7027,22 +7027,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7050,30 +7050,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7081,89 +7081,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7172,34 +7172,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7208,13 +7208,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7223,13 +7223,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7242,7 +7242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7255,7 +7255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7268,7 +7268,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7280,7 +7280,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7294,7 +7294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7307,7 +7307,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7320,7 +7320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7332,23 +7332,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7358,7 +7358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7366,37 +7366,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7408,7 +7408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7778,193 +7778,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7973,15 +7973,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7991,11 +7991,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8003,47 +8003,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8051,11 +8051,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8063,43 +8063,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8108,7 +8108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8118,7 +8118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8127,7 +8127,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8137,7 +8137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8146,7 +8146,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8156,7 +8156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8165,7 +8165,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8175,7 +8175,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8184,7 +8184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8193,7 +8193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8201,7 +8201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8210,7 +8210,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8219,7 +8219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8228,11 +8228,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8240,7 +8240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8300,15 +8300,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8322,7 +8322,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8330,11 +8330,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8349,7 +8349,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8359,7 +8359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8370,7 +8370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8380,7 +8380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8389,7 +8389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8398,7 +8398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8407,7 +8407,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8417,7 +8417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8427,23 +8427,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8452,7 +8452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8461,7 +8461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8471,7 +8471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8480,7 +8480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8490,7 +8490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8501,7 +8501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8512,15 +8512,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8531,7 +8531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8544,11 +8544,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8556,7 +8556,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8564,7 +8564,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8712,15 +8712,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8744,15 +8744,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8761,7 +8761,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8769,14 +8769,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8784,7 +8784,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8792,7 +8792,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8800,7 +8800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8808,14 +8808,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8823,7 +8823,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8831,22 +8831,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8922,54 +8922,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8977,7 +8977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8985,79 +8985,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9065,7 +9065,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9073,7 +9073,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9081,7 +9081,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9089,7 +9089,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9097,7 +9097,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9105,7 +9105,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9113,7 +9113,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9121,7 +9121,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9129,117 +9129,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9247,14 +9247,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9264,7 +9264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9276,7 +9276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9286,7 +9286,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9296,15 +9296,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9312,26 +9312,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9339,23 +9339,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9363,14 +9363,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9378,25 +9378,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9404,7 +9404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9412,14 +9412,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9448,19 +9448,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9468,11 +9468,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9480,54 +9480,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9535,59 +9535,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9595,23 +9595,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9620,26 +9620,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9647,29 +9647,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9678,22 +9678,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9701,15 +9701,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9718,15 +9718,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9735,41 +9735,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9777,11 +9777,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9806,7 +9806,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9816,11 +9816,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9828,11 +9828,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9840,7 +9840,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10174,15 +10174,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10190,19 +10190,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10210,7 +10210,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10218,12 +10218,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10231,14 +10231,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10246,33 +10246,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10280,7 +10280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10288,19 +10288,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10308,7 +10308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10316,7 +10316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10326,7 +10326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10336,11 +10336,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10348,33 +10348,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10382,34 +10382,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11019,7 +11019,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11044,19 +11044,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11066,19 +11066,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11088,7 +11088,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11096,11 +11096,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11110,7 +11110,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11118,7 +11118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11328,11 +11328,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11340,11 +11340,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11399,19 +11399,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11420,7 +11420,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11481,23 +11481,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11505,82 +11505,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11588,7 +11588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11596,11 +11596,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11608,7 +11608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11617,7 +11617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11628,22 +11628,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11652,7 +11652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11661,7 +11661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11670,7 +11670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11679,33 +11679,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11713,7 +11713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11721,7 +11721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12028,23 +12028,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12052,40 +12052,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12093,15 +12093,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12109,55 +12109,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12165,11 +12165,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12177,7 +12177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12185,11 +12185,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12197,11 +12197,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12212,114 +12212,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12330,7 +12330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12340,7 +12340,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12350,7 +12350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12360,7 +12360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12368,7 +12368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12378,7 +12378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12386,7 +12386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12396,7 +12396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12404,47 +12404,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12453,45 +12453,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12504,23 +12504,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12530,7 +12530,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12539,7 +12539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12548,7 +12548,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12556,7 +12556,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12564,7 +12564,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12572,7 +12572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12581,118 +12581,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12929,7 +12929,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12939,19 +12939,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12961,15 +12961,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13064,15 +13064,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13080,7 +13080,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13088,14 +13088,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13103,7 +13103,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13111,23 +13111,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13135,15 +13135,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13230,11 +13230,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13242,19 +13242,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13262,19 +13262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13372,11 +13372,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13384,19 +13384,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13404,15 +13404,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13510,11 +13510,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13522,11 +13522,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 #[repr(C)]
@@ -13571,26 +13571,26 @@ fn bindgen_test_layout_timeval() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13598,34 +13598,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13633,7 +13633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13642,7 +13642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13651,7 +13651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13659,7 +13659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13667,21 +13667,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13689,7 +13689,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13697,7 +13697,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13705,7 +13705,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13714,7 +13714,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13722,11 +13722,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13753,51 +13753,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13807,70 +13807,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13878,15 +13878,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13895,7 +13895,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13904,7 +13904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13915,7 +13915,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13925,11 +13925,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13940,7 +13940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -14013,15 +14013,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14030,7 +14030,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14041,7 +14041,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14052,7 +14052,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14065,7 +14065,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14077,7 +14077,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14086,7 +14086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14095,43 +14095,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14139,7 +14139,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14147,7 +14147,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14156,7 +14156,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14165,40 +14165,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14207,11 +14207,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14219,7 +14219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14230,19 +14230,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14250,19 +14250,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14277,7 +14277,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14285,14 +14285,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14300,114 +14300,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14415,11 +14415,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14427,7 +14427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14435,7 +14435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14443,7 +14443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14454,75 +14454,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14530,19 +14530,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14634,19 +14634,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14654,11 +14654,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14666,15 +14666,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14720,43 +14720,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14764,7 +14764,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14773,7 +14773,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14781,7 +14781,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14790,7 +14790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14802,11 +14802,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14860,28 +14860,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14890,7 +14890,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14900,7 +14900,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14911,7 +14911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14922,7 +14922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14933,47 +14933,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14983,7 +14983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14991,14 +14991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -15006,11 +15006,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15018,11 +15018,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15030,11 +15030,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15042,7 +15042,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15198,19 +15198,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15218,19 +15218,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15238,7 +15238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15248,53 +15248,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15302,7 +15302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15311,7 +15311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15321,7 +15321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15331,7 +15331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15341,7 +15341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15351,7 +15351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15362,7 +15362,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15372,7 +15372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15382,7 +15382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15392,7 +15392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15402,7 +15402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15411,7 +15411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15419,7 +15419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15430,7 +15430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15439,7 +15439,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15448,7 +15448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15456,11 +15456,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15470,15 +15470,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15532,92 +15532,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15625,7 +15625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15634,15 +15634,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15650,11 +15650,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15662,22 +15662,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15687,7 +15687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15695,7 +15695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15817,11 +15817,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15829,11 +15829,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15841,11 +15841,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15853,14 +15853,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15877,7 +15877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15886,7 +15886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15897,7 +15897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15908,7 +15908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15962,23 +15962,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15986,7 +15986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15994,7 +15994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -16002,7 +16002,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -16011,19 +16011,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16031,11 +16031,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16045,7 +16045,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16053,83 +16053,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16267,11 +16267,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16280,11 +16280,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16295,11 +16295,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16314,7 +16314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16329,7 +16329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16347,7 +16347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16362,66 +16362,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16432,7 +16432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16440,7 +16440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16449,7 +16449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16457,102 +16457,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16560,40 +16560,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16602,7 +16602,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16611,7 +16611,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16619,7 +16619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16627,7 +16627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16637,7 +16637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16645,7 +16645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16653,7 +16653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16663,7 +16663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16673,7 +16673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16681,7 +16681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16689,7 +16689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16699,7 +16699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16707,11 +16707,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16719,7 +16719,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16728,7 +16728,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16736,11 +16736,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16748,7 +16748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16757,7 +16757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16766,7 +16766,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16775,7 +16775,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16784,7 +16784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16797,7 +16797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16809,7 +16809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16824,31 +16824,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16858,11 +16858,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16872,11 +16872,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16886,11 +16886,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16900,11 +16900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16914,18 +16914,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16933,18 +16933,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16954,7 +16954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16964,102 +16964,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17067,28 +17067,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17096,7 +17096,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17104,7 +17104,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17114,31 +17114,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17152,7 +17152,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17166,15 +17166,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17183,7 +17183,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17191,7 +17191,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17200,22 +17200,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17223,40 +17223,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17264,11 +17264,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17276,11 +17276,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17288,11 +17288,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17300,14 +17300,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17481,7 +17481,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17495,7 +17495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17507,7 +17507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17519,11 +17519,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17531,15 +17531,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17626,7 +17626,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17638,27 +17638,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17668,7 +17668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17676,7 +17676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17684,23 +17684,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17709,7 +17709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17885,82 +17885,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17969,18 +17969,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17989,7 +17989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17998,23 +17998,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18030,7 +18030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18048,7 +18048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18061,7 +18061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18074,7 +18074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18087,7 +18087,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18097,19 +18097,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18368,7 +18368,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18376,7 +18376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18385,7 +18385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18394,22 +18394,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18417,15 +18417,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18512,66 +18512,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18580,7 +18580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18588,7 +18588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18596,7 +18596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18677,7 +18677,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18696,7 +18696,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18704,47 +18704,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19038,51 +19038,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19108,15 +19108,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19124,18 +19124,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19143,79 +19143,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19224,11 +19224,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19237,7 +19237,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19246,12 +19246,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19260,7 +19260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19269,7 +19269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19289,7 +19289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19301,7 +19301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19311,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19321,7 +19321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19332,7 +19332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19346,7 +19346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19358,7 +19358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19369,7 +19369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19382,7 +19382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19394,7 +19394,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19404,7 +19404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19414,31 +19414,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19449,7 +19449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19460,7 +19460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19473,7 +19473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19484,19 +19484,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19504,19 +19504,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19524,7 +19524,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19534,7 +19534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19542,26 +19542,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19570,7 +19570,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19578,11 +19578,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19590,11 +19590,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19604,7 +19604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19614,7 +19614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19625,7 +19625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19633,7 +19633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20134,27 +20134,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20162,51 +20162,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20219,15 +20219,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20235,7 +20235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20243,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20251,15 +20251,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20267,68 +20267,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20336,7 +20336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20344,25 +20344,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20370,14 +20370,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20385,7 +20385,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20393,7 +20393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20401,14 +20401,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20430,23 +20430,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20454,23 +20454,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20479,19 +20479,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20499,7 +20499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20507,7 +20507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20515,11 +20515,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20527,55 +20527,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20583,7 +20583,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20591,25 +20591,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20617,19 +20617,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20637,23 +20637,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20661,33 +20661,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20695,22 +20695,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20760,19 +20760,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20780,15 +20780,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20796,15 +20796,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20812,7 +20812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20820,21 +20820,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20843,7 +20843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20855,7 +20855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20867,7 +20867,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20879,19 +20879,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20899,33 +20899,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20934,11 +20934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20948,7 +20948,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20958,7 +20958,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20968,19 +20968,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20988,18 +20988,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21008,7 +21008,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21017,33 +21017,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21067,11 +21067,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21079,18 +21079,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21098,7 +21098,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21106,7 +21106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21114,21 +21114,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21157,23 +21157,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21181,11 +21181,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21194,7 +21194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21203,15 +21203,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21219,7 +21219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21227,7 +21227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21236,7 +21236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21245,7 +21245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21254,7 +21254,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21263,7 +21263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21272,259 +21272,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21532,11 +21532,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21546,7 +21546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21554,14 +21554,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21571,7 +21571,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21579,42 +21579,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21623,7 +21623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22196,11 +22196,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22208,7 +22208,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22216,54 +22216,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22271,27 +22271,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22299,7 +22299,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22308,44 +22308,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22353,34 +22353,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22388,26 +22388,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22415,18 +22415,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22434,38 +22434,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22473,25 +22473,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22499,7 +22499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22507,23 +22507,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22531,26 +22531,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22558,26 +22558,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22585,7 +22585,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22595,7 +22595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22605,7 +22605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22615,7 +22615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22627,7 +22627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22638,15 +22638,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22654,18 +22654,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22673,7 +22673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22681,28 +22681,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22712,7 +22712,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22722,7 +22722,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22732,37 +22732,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22772,66 +22772,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22840,19 +22840,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22861,7 +22861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22869,7 +22869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22878,7 +22878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22887,15 +22887,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22904,11 +22904,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22917,7 +22917,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22927,7 +22927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22936,7 +22936,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22946,11 +22946,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22958,7 +22958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22966,7 +22966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22974,21 +22974,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22996,7 +22996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23005,7 +23005,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23015,11 +23015,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23027,7 +23027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23035,28 +23035,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23066,7 +23066,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23076,7 +23076,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23086,7 +23086,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23096,7 +23096,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23106,7 +23106,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23116,14 +23116,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23132,7 +23132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23141,34 +23141,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23176,26 +23176,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23206,7 +23206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23216,11 +23216,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23228,19 +23228,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23257,19 +23257,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23356,15 +23356,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23372,14 +23372,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23498,18 +23498,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23517,7 +23517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23525,202 +23525,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23728,15 +23728,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23745,50 +23745,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23797,7 +23797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23807,7 +23807,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23815,7 +23815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23823,7 +23823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23831,19 +23831,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23852,11 +23852,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23864,81 +23864,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23947,11 +23947,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23959,7 +23959,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23967,7 +23967,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23979,109 +23979,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24089,7 +24089,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24097,20 +24097,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24118,7 +24118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24126,42 +24126,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24173,14 +24173,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24190,7 +24190,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24200,7 +24200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24210,7 +24210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24222,7 +24222,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24233,7 +24233,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24247,7 +24247,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24256,7 +24256,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24266,7 +24266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24276,7 +24276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24287,7 +24287,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24301,7 +24301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24310,7 +24310,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24319,11 +24319,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24332,7 +24332,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24341,7 +24341,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24350,15 +24350,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24367,7 +24367,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24376,15 +24376,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24393,7 +24393,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24402,23 +24402,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24427,7 +24427,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24436,15 +24436,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24453,7 +24453,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24462,15 +24462,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24479,7 +24479,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24488,15 +24488,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24505,7 +24505,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24514,21 +24514,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24537,7 +24537,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24546,7 +24546,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24558,7 +24558,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24570,7 +24570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24579,7 +24579,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24588,15 +24588,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24605,7 +24605,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24614,15 +24614,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24631,7 +24631,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24640,7 +24640,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24652,7 +24652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24664,7 +24664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24673,7 +24673,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24682,15 +24682,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24699,7 +24699,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24708,15 +24708,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24725,7 +24725,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24734,7 +24734,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24746,7 +24746,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24758,7 +24758,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24767,7 +24767,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24776,15 +24776,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24793,7 +24793,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24802,15 +24802,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24819,7 +24819,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24828,7 +24828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24840,7 +24840,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24852,7 +24852,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24861,7 +24861,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24870,15 +24870,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24890,7 +24890,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24902,7 +24902,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24914,7 +24914,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24926,7 +24926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24935,7 +24935,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24947,7 +24947,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24959,7 +24959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24971,7 +24971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24980,7 +24980,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24992,7 +24992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -25005,7 +25005,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -25019,7 +25019,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -25027,7 +25027,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -25035,7 +25035,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -25044,11 +25044,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25056,27 +25056,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25086,7 +25086,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25094,7 +25094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25109,74 +25109,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25277,19 +25277,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25354,11 +25354,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25445,11 +25445,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25457,42 +25457,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25567,15 +25567,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25588,7 +25588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25603,18 +25603,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25623,14 +25623,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25639,7 +25639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25650,7 +25650,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25659,7 +25659,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25671,7 +25671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25683,18 +25683,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25702,14 +25702,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25717,7 +25717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25731,7 +25731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25746,7 +25746,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25759,7 +25759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25774,7 +25774,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27482,15 +27482,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27498,26 +27498,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27525,14 +27525,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27764,15 +27764,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27780,26 +27780,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27807,26 +27807,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27834,29 +27834,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27864,19 +27864,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27884,18 +27884,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27903,7 +27903,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27911,15 +27911,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27927,26 +27927,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27954,22 +27954,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27977,14 +27977,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27992,7 +27992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -28000,14 +28000,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28015,15 +28015,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28031,33 +28031,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28065,26 +28065,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28092,26 +28092,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28119,26 +28119,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28146,26 +28146,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28173,26 +28173,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28200,26 +28200,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28227,26 +28227,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28254,26 +28254,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28281,38 +28281,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28320,26 +28320,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28347,70 +28347,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28421,7 +28421,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28429,7 +28429,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28439,7 +28439,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28537,7 +28537,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28548,11 +28548,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28561,7 +28561,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28570,7 +28570,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28579,7 +28579,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28588,7 +28588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28597,7 +28597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28606,7 +28606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28615,67 +28615,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28684,14 +28684,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28699,7 +28699,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28709,7 +28709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28718,7 +28718,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28727,7 +28727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28736,7 +28736,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28746,11 +28746,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28758,70 +28758,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28839,43 +28839,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28885,7 +28885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28894,7 +28894,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28903,7 +28903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28911,11 +28911,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28981,119 +28981,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLS_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLS_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLS_with_buffers_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_connect_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_accept_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_is_server"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_is_dtls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_rbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_wbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_rbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_wbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_rfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_wfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_rfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_wfd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_do_handshake"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_accept"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29101,7 +29101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_peek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29109,15 +29109,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_has_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29125,220 +29125,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_key_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_error_description"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_mtu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_clear_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_options"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_clear_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29351,7 +29351,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29364,71 +29364,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_certs_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_privatekey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29436,7 +29436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29444,7 +29444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29452,7 +29452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29460,26 +29460,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29487,7 +29487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29495,7 +29495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29505,7 +29505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29515,19 +29515,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29535,7 +29535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29543,7 +29543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29552,7 +29552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29561,7 +29561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29569,7 +29569,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29577,7 +29577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29585,7 +29585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29593,7 +29593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29601,7 +29601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_certificate_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29609,7 +29609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29617,7 +29617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29625,29 +29625,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29736,18 +29736,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_private_key_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_can_release_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29772,156 +29772,156 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_ciphersuites"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_ciphersuites"]
     pub fn SSL_set_ciphersuites(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_is_init_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_in_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_in_false_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29929,11 +29929,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_tls_unique"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29942,23 +29942,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_extms_support"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_current_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_session_reused"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_export_keying_material"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29971,7 +29971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29980,7 +29980,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29989,27 +29989,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30017,7 +30017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30025,7 +30025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -30033,29 +30033,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -30063,25 +30063,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30089,7 +30089,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30097,7 +30097,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30105,22 +30105,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30128,19 +30128,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30148,7 +30148,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30156,19 +30156,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30176,34 +30176,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30211,7 +30211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30219,44 +30219,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30265,7 +30265,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30273,7 +30273,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30282,13 +30282,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30302,7 +30302,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30315,11 +30315,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30327,7 +30327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30335,7 +30335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30427,14 +30427,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30442,15 +30442,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30458,7 +30458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30466,29 +30466,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_curves_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_curve_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30496,11 +30496,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30508,7 +30508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_groups"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30516,21 +30516,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_groups_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30543,7 +30543,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30560,7 +30560,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30570,7 +30570,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_custom_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30580,15 +30580,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_verify_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30599,7 +30599,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30610,83 +30610,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_verify_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30694,19 +30694,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_verify_result"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30719,51 +30719,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30771,7 +30771,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30779,87 +30779,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_client_CA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_dup_CA_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_servername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_servername_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30872,18 +30872,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30891,7 +30891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30899,7 +30899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30916,7 +30916,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30924,11 +30924,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30938,7 +30938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30946,7 +30946,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_has_application_settings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30967,7 +30967,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30976,7 +30976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30991,7 +30991,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31008,7 +31008,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -31016,7 +31016,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_select_next_proto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -31027,29 +31027,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31126,29 +31126,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31164,7 +31164,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31180,7 +31180,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31194,7 +31194,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31208,29 +31208,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_psk_identity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31239,7 +31239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31352,22 +31352,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_quic_read_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_quic_write_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_provide_quic_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31376,25 +31376,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quic_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31402,7 +31402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31410,11 +31410,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31422,35 +31422,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_in_early_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_early_data_accepted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31472,21 +31472,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31494,7 +31494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31502,7 +31502,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31510,7 +31510,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31521,19 +31521,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31543,12 +31543,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31556,34 +31556,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_ech_accepted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31591,14 +31591,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31608,7 +31608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31616,14 +31616,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31633,7 +31633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31641,14 +31641,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31658,7 +31658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_ivs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31667,11 +31667,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_key_block_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_generate_key_block"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31679,26 +31679,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_read_sequence"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_write_sequence"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31708,11 +31708,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31720,7 +31720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31737,11 +31737,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_msg_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31758,11 +31758,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31771,7 +31771,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31779,14 +31779,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31796,46 +31796,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_total_renegotiations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -32029,7 +32029,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -32038,7 +32038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32047,7 +32047,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32056,19 +32056,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32081,7 +32081,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32093,7 +32093,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32106,7 +32106,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_info_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32118,77 +32118,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_state_string_long"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_client_random"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_server_random"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_description"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32196,11 +32196,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32211,126 +32211,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_get_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLv23_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_2_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_2_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLS_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLS_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLv23_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSLv23_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_2_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_TLSv1_2_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLS_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLS_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32343,7 +32343,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32356,98 +32356,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_num_renegotiations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_read_ahead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32455,7 +32455,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32467,11 +32467,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32479,61 +32479,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_load_error_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_current_compression"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_current_expansion"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32546,7 +32546,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32559,7 +32559,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32567,7 +32567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32575,25 +32575,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32673,26 +32673,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_cache_hit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_default_timeout"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_cipher_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32705,11 +32705,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_want"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32717,7 +32717,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_peer_finished"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32725,15 +32725,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_type_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_alert_desc_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_state_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32743,42 +32743,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_f_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_BIO_set_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32786,33 +32786,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get1_session"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32820,11 +32820,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32836,18 +32836,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -32863,15 +32863,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -4223,7 +4223,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4231,7 +4231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4239,15 +4239,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4259,7 +4259,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4268,7 +4268,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4279,7 +4279,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4290,7 +4290,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4302,7 +4302,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4312,7 +4312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4322,7 +4322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4333,7 +4333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4919,27 +4919,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4947,29 +4947,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4977,7 +4977,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4985,38 +4985,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5025,18 +5025,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5045,18 +5045,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5065,7 +5065,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5073,11 +5073,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5088,30 +5088,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5150,30 +5150,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5183,15 +5183,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -5319,27 +5319,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5347,11 +5347,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5359,22 +5359,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5383,7 +5383,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5392,35 +5392,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5430,7 +5430,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5490,7 +5490,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5596,19 +5596,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5621,7 +5621,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5635,7 +5635,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5646,29 +5646,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5724,7 +5724,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5735,7 +5735,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5748,7 +5748,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5760,7 +5760,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5769,7 +5769,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5780,7 +5780,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5807,23 +5807,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5831,7 +5831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5839,7 +5839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5847,7 +5847,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5855,15 +5855,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5872,7 +5872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5880,7 +5880,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5889,67 +5889,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5975,7 +5975,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5983,68 +5983,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6052,7 +6052,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6060,7 +6060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6069,11 +6069,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6082,15 +6082,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6098,11 +6098,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6110,22 +6110,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6133,30 +6133,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6164,89 +6164,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6255,34 +6255,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6291,13 +6291,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6306,13 +6306,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6325,7 +6325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6338,7 +6338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6351,7 +6351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6363,7 +6363,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6377,7 +6377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6390,7 +6390,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6403,7 +6403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6415,23 +6415,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6441,7 +6441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6449,37 +6449,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6491,7 +6491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6861,193 +6861,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7056,15 +7056,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7074,11 +7074,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7086,47 +7086,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7134,11 +7134,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7146,43 +7146,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7191,7 +7191,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7201,7 +7201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7210,7 +7210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7220,7 +7220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7229,7 +7229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7239,7 +7239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7248,7 +7248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7258,7 +7258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7267,7 +7267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7276,7 +7276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7284,7 +7284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7293,7 +7293,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7302,7 +7302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7311,11 +7311,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7323,7 +7323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7383,15 +7383,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7405,7 +7405,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7413,11 +7413,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7432,7 +7432,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7442,7 +7442,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7453,7 +7453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7463,7 +7463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7472,7 +7472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7481,7 +7481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7490,7 +7490,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7500,7 +7500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7510,23 +7510,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7535,7 +7535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7544,7 +7544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7554,7 +7554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7563,7 +7563,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7573,7 +7573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7584,7 +7584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7595,15 +7595,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7614,7 +7614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7627,11 +7627,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7639,7 +7639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7647,7 +7647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7795,15 +7795,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7827,15 +7827,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7844,7 +7844,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7852,14 +7852,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7867,7 +7867,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7875,7 +7875,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7883,7 +7883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7891,14 +7891,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7906,7 +7906,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7914,22 +7914,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8005,54 +8005,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8060,7 +8060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8068,79 +8068,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8148,7 +8148,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8156,7 +8156,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8164,7 +8164,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8172,7 +8172,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8180,7 +8180,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8188,7 +8188,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8196,7 +8196,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8204,7 +8204,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8212,117 +8212,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8330,14 +8330,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8347,7 +8347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8359,7 +8359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8369,7 +8369,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8379,15 +8379,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8395,26 +8395,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8422,23 +8422,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8446,14 +8446,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8461,25 +8461,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8487,7 +8487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8495,14 +8495,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8531,19 +8531,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8551,11 +8551,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8563,54 +8563,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8618,59 +8618,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8678,23 +8678,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -8703,26 +8703,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8730,29 +8730,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -8761,22 +8761,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8784,15 +8784,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8801,15 +8801,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -8818,41 +8818,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8860,11 +8860,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8889,7 +8889,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8899,11 +8899,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8911,11 +8911,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8923,7 +8923,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9257,15 +9257,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9273,19 +9273,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9293,7 +9293,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9301,12 +9301,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9314,14 +9314,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9329,33 +9329,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9363,7 +9363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9371,19 +9371,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9391,7 +9391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9399,7 +9399,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9409,7 +9409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9419,11 +9419,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9431,33 +9431,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9465,34 +9465,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10102,7 +10102,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10127,19 +10127,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10149,19 +10149,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10171,7 +10171,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10179,11 +10179,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10193,7 +10193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10201,7 +10201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10411,11 +10411,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10423,11 +10423,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10482,19 +10482,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10503,7 +10503,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10564,23 +10564,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10588,82 +10588,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10671,7 +10671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10679,11 +10679,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10691,7 +10691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10700,7 +10700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10711,22 +10711,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10735,7 +10735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10744,7 +10744,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10753,7 +10753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10762,33 +10762,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10796,7 +10796,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10804,7 +10804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11111,23 +11111,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11135,40 +11135,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11176,15 +11176,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11192,55 +11192,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11248,11 +11248,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11260,7 +11260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11268,11 +11268,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11280,11 +11280,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11295,114 +11295,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11413,7 +11413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11423,7 +11423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11433,7 +11433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11443,7 +11443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11451,7 +11451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11461,7 +11461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11469,7 +11469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11479,7 +11479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11487,47 +11487,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11536,45 +11536,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11587,23 +11587,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11613,7 +11613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11622,7 +11622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11631,7 +11631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11639,7 +11639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11647,7 +11647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11655,7 +11655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11664,118 +11664,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12012,7 +12012,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12022,19 +12022,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12044,15 +12044,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12147,15 +12147,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12163,7 +12163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12171,14 +12171,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12186,7 +12186,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12194,23 +12194,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12218,15 +12218,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12313,11 +12313,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12325,19 +12325,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12345,19 +12345,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12455,11 +12455,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12467,19 +12467,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12487,15 +12487,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12593,11 +12593,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12605,34 +12605,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12640,34 +12640,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12675,7 +12675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12684,7 +12684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12693,7 +12693,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12701,7 +12701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12709,21 +12709,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12731,7 +12731,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12739,7 +12739,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12747,7 +12747,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12756,7 +12756,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12764,11 +12764,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12795,51 +12795,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12849,70 +12849,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12920,15 +12920,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12937,7 +12937,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12946,7 +12946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12957,7 +12957,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12967,11 +12967,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12982,7 +12982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13055,15 +13055,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13072,7 +13072,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13083,7 +13083,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13094,7 +13094,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13107,7 +13107,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13119,7 +13119,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13128,7 +13128,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13137,43 +13137,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13181,7 +13181,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13189,7 +13189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13198,7 +13198,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13207,40 +13207,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13249,11 +13249,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13261,7 +13261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13272,19 +13272,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13292,19 +13292,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13319,7 +13319,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13327,14 +13327,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13342,114 +13342,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13457,11 +13457,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13469,7 +13469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13477,7 +13477,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13485,7 +13485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13496,75 +13496,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13572,19 +13572,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13676,19 +13676,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13696,11 +13696,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13708,15 +13708,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13762,43 +13762,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13806,7 +13806,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13815,7 +13815,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13823,7 +13823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13832,7 +13832,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13844,11 +13844,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13902,28 +13902,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13932,7 +13932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13942,7 +13942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13953,7 +13953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13964,7 +13964,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13975,47 +13975,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14025,7 +14025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14033,14 +14033,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14048,11 +14048,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14060,11 +14060,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14072,11 +14072,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14084,7 +14084,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14240,19 +14240,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14260,19 +14260,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14280,7 +14280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14290,53 +14290,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14344,7 +14344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14353,7 +14353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14363,7 +14363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14373,7 +14373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14383,7 +14383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14393,7 +14393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14404,7 +14404,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14414,7 +14414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14424,7 +14424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14434,7 +14434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14444,7 +14444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14453,7 +14453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14461,7 +14461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14472,7 +14472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14481,7 +14481,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14490,7 +14490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14498,11 +14498,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14512,15 +14512,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14574,92 +14574,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14667,7 +14667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14676,15 +14676,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14692,11 +14692,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14704,22 +14704,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14729,7 +14729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14737,7 +14737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14859,11 +14859,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14871,11 +14871,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14883,11 +14883,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14895,14 +14895,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14919,7 +14919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14928,7 +14928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14939,7 +14939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14950,7 +14950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15004,23 +15004,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15028,7 +15028,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15036,7 +15036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15044,7 +15044,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15053,19 +15053,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15073,11 +15073,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15087,7 +15087,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15095,83 +15095,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15309,11 +15309,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15322,11 +15322,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15337,11 +15337,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15356,7 +15356,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15371,7 +15371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15389,7 +15389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15404,66 +15404,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15474,7 +15474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15482,7 +15482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15491,7 +15491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15499,102 +15499,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15602,40 +15602,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15644,7 +15644,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15653,7 +15653,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15661,7 +15661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15669,7 +15669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15679,7 +15679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15687,7 +15687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15695,7 +15695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15705,7 +15705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15715,7 +15715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15723,7 +15723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15731,7 +15731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15741,7 +15741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15749,11 +15749,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15761,7 +15761,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15770,7 +15770,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15778,11 +15778,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15790,7 +15790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15799,7 +15799,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15808,7 +15808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15817,7 +15817,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15826,7 +15826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15839,7 +15839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15851,7 +15851,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15866,31 +15866,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15900,11 +15900,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15914,11 +15914,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15928,11 +15928,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15942,11 +15942,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15956,18 +15956,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15975,18 +15975,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15996,7 +15996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16006,102 +16006,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16109,28 +16109,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16138,7 +16138,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16146,7 +16146,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16156,31 +16156,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16194,7 +16194,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16208,15 +16208,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16225,7 +16225,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16233,7 +16233,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16242,22 +16242,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16265,40 +16265,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16306,11 +16306,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16318,11 +16318,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16330,11 +16330,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16342,14 +16342,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16523,7 +16523,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16537,7 +16537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16549,7 +16549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16561,11 +16561,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16573,15 +16573,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16668,7 +16668,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16680,27 +16680,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16710,7 +16710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16718,7 +16718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16726,23 +16726,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16751,7 +16751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16927,82 +16927,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17011,18 +17011,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17031,7 +17031,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17040,23 +17040,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17072,7 +17072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17090,7 +17090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17103,7 +17103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17116,7 +17116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17129,7 +17129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17139,19 +17139,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17410,7 +17410,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17418,7 +17418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17427,7 +17427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17436,22 +17436,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17459,15 +17459,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17554,66 +17554,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17622,7 +17622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17630,7 +17630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17638,7 +17638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17719,7 +17719,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17738,7 +17738,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17746,47 +17746,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18080,51 +18080,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18150,15 +18150,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18166,18 +18166,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18185,79 +18185,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18266,11 +18266,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18279,7 +18279,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18288,12 +18288,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18302,7 +18302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18311,7 +18311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18319,7 +18319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18331,7 +18331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18343,7 +18343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18353,7 +18353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18363,7 +18363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18374,7 +18374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18388,7 +18388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18400,7 +18400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18411,7 +18411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18424,7 +18424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18436,7 +18436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18446,7 +18446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18456,31 +18456,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18491,7 +18491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18502,7 +18502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18515,7 +18515,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18526,19 +18526,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18546,19 +18546,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18566,7 +18566,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18576,7 +18576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18584,26 +18584,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18612,7 +18612,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18620,11 +18620,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18632,11 +18632,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18646,7 +18646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18656,7 +18656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18667,7 +18667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18675,7 +18675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19176,27 +19176,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19204,51 +19204,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19261,15 +19261,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19277,7 +19277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19285,7 +19285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19293,15 +19293,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19309,68 +19309,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19378,7 +19378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19386,25 +19386,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19412,14 +19412,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19427,7 +19427,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19435,7 +19435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19443,14 +19443,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19472,23 +19472,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19496,23 +19496,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19521,19 +19521,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19541,7 +19541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19549,7 +19549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19557,11 +19557,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19569,55 +19569,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19625,7 +19625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19633,25 +19633,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19659,19 +19659,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19679,23 +19679,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19703,33 +19703,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19737,22 +19737,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19802,19 +19802,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19822,15 +19822,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19838,15 +19838,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19854,7 +19854,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19862,21 +19862,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19885,7 +19885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19897,7 +19897,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19909,7 +19909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19921,19 +19921,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19941,33 +19941,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19976,11 +19976,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19990,7 +19990,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20000,7 +20000,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20010,19 +20010,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20030,18 +20030,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20050,7 +20050,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20059,33 +20059,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20109,11 +20109,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20121,18 +20121,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20140,7 +20140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20148,7 +20148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20156,21 +20156,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20199,23 +20199,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20223,11 +20223,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20236,7 +20236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20245,15 +20245,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20261,7 +20261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20269,7 +20269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20278,7 +20278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20287,7 +20287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20296,7 +20296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20305,7 +20305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20314,259 +20314,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20574,11 +20574,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20588,7 +20588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20596,14 +20596,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20613,7 +20613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20621,42 +20621,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20665,7 +20665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21238,11 +21238,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21250,7 +21250,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21258,54 +21258,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21313,27 +21313,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21341,7 +21341,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21350,44 +21350,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21395,34 +21395,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21430,26 +21430,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21457,18 +21457,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21476,38 +21476,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21515,25 +21515,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21541,7 +21541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21549,23 +21549,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21573,26 +21573,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21600,26 +21600,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21627,7 +21627,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21637,7 +21637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21647,7 +21647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21657,7 +21657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21669,7 +21669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21680,15 +21680,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21696,18 +21696,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21715,7 +21715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21723,28 +21723,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21754,7 +21754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21764,7 +21764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21774,37 +21774,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21814,66 +21814,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21882,19 +21882,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21903,7 +21903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21911,7 +21911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21920,7 +21920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21929,15 +21929,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21946,11 +21946,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21959,7 +21959,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21969,7 +21969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21978,7 +21978,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21988,11 +21988,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22000,7 +22000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22008,7 +22008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22016,21 +22016,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22038,7 +22038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22047,7 +22047,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22057,11 +22057,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22069,7 +22069,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22077,28 +22077,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22108,7 +22108,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22118,7 +22118,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22128,7 +22128,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22138,7 +22138,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22148,7 +22148,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22158,14 +22158,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22174,7 +22174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22183,34 +22183,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22218,26 +22218,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22248,7 +22248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22258,11 +22258,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22270,19 +22270,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22299,19 +22299,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22398,15 +22398,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22414,14 +22414,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22540,18 +22540,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22559,7 +22559,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22567,202 +22567,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22770,15 +22770,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22787,50 +22787,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22839,7 +22839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22849,7 +22849,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22857,7 +22857,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22865,7 +22865,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22873,19 +22873,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22894,11 +22894,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22906,81 +22906,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22989,11 +22989,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23001,7 +23001,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23009,7 +23009,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23021,109 +23021,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23131,7 +23131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23139,20 +23139,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23160,7 +23160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23168,42 +23168,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23215,14 +23215,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23232,7 +23232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23242,7 +23242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23252,7 +23252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23264,7 +23264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23275,7 +23275,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23289,7 +23289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23298,7 +23298,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23308,7 +23308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23318,7 +23318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23329,7 +23329,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23343,7 +23343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23352,7 +23352,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23361,11 +23361,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23374,7 +23374,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23383,7 +23383,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23392,15 +23392,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23409,7 +23409,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23418,15 +23418,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23435,7 +23435,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23444,23 +23444,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23469,7 +23469,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23478,15 +23478,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23495,7 +23495,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23504,15 +23504,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23521,7 +23521,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23530,15 +23530,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23547,7 +23547,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23556,21 +23556,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23579,7 +23579,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23588,7 +23588,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23600,7 +23600,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23612,7 +23612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23621,7 +23621,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23630,15 +23630,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23647,7 +23647,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23656,15 +23656,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23673,7 +23673,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23682,7 +23682,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23694,7 +23694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23706,7 +23706,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23715,7 +23715,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23724,15 +23724,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23741,7 +23741,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23750,15 +23750,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23767,7 +23767,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23776,7 +23776,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23788,7 +23788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23800,7 +23800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23809,7 +23809,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23818,15 +23818,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23835,7 +23835,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23844,15 +23844,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23861,7 +23861,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23870,7 +23870,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23882,7 +23882,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23894,7 +23894,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23903,7 +23903,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23912,15 +23912,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23932,7 +23932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23944,7 +23944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23956,7 +23956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23968,7 +23968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23977,7 +23977,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23989,7 +23989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24001,7 +24001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24013,7 +24013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24022,7 +24022,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24034,7 +24034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24047,7 +24047,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24061,7 +24061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24069,7 +24069,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24077,7 +24077,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24086,11 +24086,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24098,27 +24098,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24128,7 +24128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24136,7 +24136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24151,74 +24151,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24319,19 +24319,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24396,11 +24396,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24487,11 +24487,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24499,42 +24499,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24609,15 +24609,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24630,7 +24630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24645,18 +24645,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24665,14 +24665,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24681,7 +24681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24692,7 +24692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24701,7 +24701,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24713,7 +24713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24725,18 +24725,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24744,14 +24744,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24759,7 +24759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24773,7 +24773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24788,7 +24788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24801,7 +24801,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24816,7 +24816,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26524,15 +26524,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26540,26 +26540,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26567,14 +26567,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26806,15 +26806,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26822,26 +26822,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26849,26 +26849,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26876,29 +26876,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26906,19 +26906,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26926,18 +26926,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26945,7 +26945,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26953,15 +26953,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26969,26 +26969,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26996,22 +26996,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27019,14 +27019,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27034,7 +27034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27042,14 +27042,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27057,15 +27057,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27073,33 +27073,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27107,26 +27107,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27134,26 +27134,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27161,26 +27161,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27188,26 +27188,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27215,26 +27215,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27242,26 +27242,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27269,26 +27269,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27296,26 +27296,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27323,38 +27323,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27362,26 +27362,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27389,70 +27389,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27463,7 +27463,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27471,7 +27471,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27481,7 +27481,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27579,7 +27579,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27590,11 +27590,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27603,7 +27603,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27612,7 +27612,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27621,7 +27621,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27630,7 +27630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27639,7 +27639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27648,7 +27648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27657,67 +27657,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27726,14 +27726,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27741,7 +27741,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27751,7 +27751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27760,7 +27760,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27769,7 +27769,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27778,7 +27778,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27788,11 +27788,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27800,70 +27800,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27881,43 +27881,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27927,7 +27927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27936,7 +27936,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27945,7 +27945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27953,15 +27953,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -27977,15 +27977,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto_ssl.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -5215,7 +5215,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5223,7 +5223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5231,15 +5231,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5251,7 +5251,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5260,7 +5260,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5271,7 +5271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5282,7 +5282,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5294,7 +5294,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5304,7 +5304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5314,7 +5314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5325,7 +5325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5911,27 +5911,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5939,29 +5939,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5969,7 +5969,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5977,38 +5977,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6017,18 +6017,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6037,18 +6037,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6057,7 +6057,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6065,11 +6065,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6080,30 +6080,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -6142,30 +6142,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6175,15 +6175,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6311,27 +6311,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6339,11 +6339,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6351,22 +6351,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6375,7 +6375,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6384,35 +6384,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6422,7 +6422,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6482,7 +6482,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6588,19 +6588,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6613,7 +6613,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6627,7 +6627,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6638,29 +6638,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6716,7 +6716,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6727,7 +6727,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6740,7 +6740,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6752,7 +6752,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6761,7 +6761,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6772,7 +6772,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6799,23 +6799,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6823,7 +6823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6831,7 +6831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6839,7 +6839,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6847,15 +6847,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6864,7 +6864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6872,7 +6872,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6881,67 +6881,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6967,7 +6967,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6975,68 +6975,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7044,7 +7044,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7052,7 +7052,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7061,11 +7061,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7074,15 +7074,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7090,11 +7090,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7102,22 +7102,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7125,30 +7125,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7156,89 +7156,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7247,34 +7247,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7283,13 +7283,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7298,13 +7298,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7317,7 +7317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7330,7 +7330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7343,7 +7343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7355,7 +7355,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7369,7 +7369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7382,7 +7382,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7395,7 +7395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7407,23 +7407,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7433,7 +7433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7441,37 +7441,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7483,7 +7483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7853,193 +7853,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8048,15 +8048,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8066,11 +8066,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8078,47 +8078,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8126,11 +8126,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8138,43 +8138,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8183,7 +8183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8193,7 +8193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8202,7 +8202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8212,7 +8212,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8221,7 +8221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8231,7 +8231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8240,7 +8240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8250,7 +8250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8259,7 +8259,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8268,7 +8268,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8276,7 +8276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8285,7 +8285,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8294,7 +8294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8303,11 +8303,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8315,7 +8315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8375,15 +8375,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8397,7 +8397,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8405,11 +8405,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8424,7 +8424,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8434,7 +8434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8445,7 +8445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8455,7 +8455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8464,7 +8464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8473,7 +8473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8482,7 +8482,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8492,7 +8492,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8502,23 +8502,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8527,7 +8527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8536,7 +8536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8546,7 +8546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8555,7 +8555,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8565,7 +8565,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8576,7 +8576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8587,15 +8587,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8606,7 +8606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8619,11 +8619,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8631,7 +8631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8639,7 +8639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8787,15 +8787,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8819,15 +8819,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8836,7 +8836,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8844,14 +8844,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8859,7 +8859,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8867,7 +8867,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8875,7 +8875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8883,14 +8883,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8898,7 +8898,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8906,22 +8906,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8997,54 +8997,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9052,7 +9052,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9060,79 +9060,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9140,7 +9140,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9148,7 +9148,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9156,7 +9156,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9164,7 +9164,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9172,7 +9172,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9180,7 +9180,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9188,7 +9188,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9196,7 +9196,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9204,117 +9204,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9322,14 +9322,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9339,7 +9339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9351,7 +9351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9361,7 +9361,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9371,15 +9371,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9387,26 +9387,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9414,23 +9414,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9438,14 +9438,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9453,25 +9453,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9479,7 +9479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9487,14 +9487,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9523,19 +9523,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9543,11 +9543,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9555,54 +9555,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9610,59 +9610,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9670,23 +9670,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9695,26 +9695,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9722,29 +9722,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9753,22 +9753,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9776,15 +9776,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9793,15 +9793,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9810,41 +9810,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9852,11 +9852,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9881,7 +9881,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9891,11 +9891,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9903,11 +9903,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9915,7 +9915,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10249,15 +10249,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10265,19 +10265,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10285,7 +10285,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10293,12 +10293,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10306,14 +10306,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10321,33 +10321,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10355,7 +10355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10363,19 +10363,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10383,7 +10383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10391,7 +10391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10401,7 +10401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10411,11 +10411,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10423,33 +10423,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10457,34 +10457,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11094,7 +11094,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11119,19 +11119,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11141,19 +11141,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11163,7 +11163,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11171,11 +11171,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11185,7 +11185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11193,7 +11193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11403,11 +11403,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11415,11 +11415,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11474,19 +11474,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11495,7 +11495,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11556,23 +11556,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11580,82 +11580,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11663,7 +11663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11671,11 +11671,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11683,7 +11683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11692,7 +11692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11703,22 +11703,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11727,7 +11727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11736,7 +11736,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11745,7 +11745,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11754,33 +11754,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11788,7 +11788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11796,7 +11796,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12103,23 +12103,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12127,40 +12127,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12168,15 +12168,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12184,55 +12184,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12240,11 +12240,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12252,7 +12252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12260,11 +12260,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12272,11 +12272,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12287,114 +12287,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12405,7 +12405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12415,7 +12415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12425,7 +12425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12435,7 +12435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12443,7 +12443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12453,7 +12453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12461,7 +12461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12471,7 +12471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12479,47 +12479,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12528,45 +12528,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12579,23 +12579,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12605,7 +12605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12614,7 +12614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12623,7 +12623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12631,7 +12631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12639,7 +12639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12647,7 +12647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12656,118 +12656,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -13004,7 +13004,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13014,19 +13014,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13036,15 +13036,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13139,15 +13139,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13155,7 +13155,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13163,14 +13163,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13178,7 +13178,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13186,23 +13186,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13210,15 +13210,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13305,11 +13305,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13317,19 +13317,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13337,19 +13337,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13447,11 +13447,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13459,19 +13459,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13479,15 +13479,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13585,11 +13585,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13597,34 +13597,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13632,34 +13632,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13667,7 +13667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13676,7 +13676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13685,7 +13685,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13693,7 +13693,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13701,21 +13701,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13723,7 +13723,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13731,7 +13731,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13739,7 +13739,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13748,7 +13748,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13756,11 +13756,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13787,51 +13787,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13841,70 +13841,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13912,15 +13912,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13929,7 +13929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13938,7 +13938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13949,7 +13949,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13959,11 +13959,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13974,7 +13974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -14047,15 +14047,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -14064,7 +14064,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14075,7 +14075,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -14086,7 +14086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14099,7 +14099,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -14111,7 +14111,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14120,7 +14120,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -14129,43 +14129,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -14173,7 +14173,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -14181,7 +14181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -14190,7 +14190,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -14199,40 +14199,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -14241,11 +14241,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14253,7 +14253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -14264,19 +14264,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -14284,19 +14284,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14311,7 +14311,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14319,14 +14319,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14334,114 +14334,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14449,11 +14449,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14461,7 +14461,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14469,7 +14469,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14477,7 +14477,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14488,75 +14488,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14564,19 +14564,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14668,19 +14668,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14688,11 +14688,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14700,15 +14700,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14754,43 +14754,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14798,7 +14798,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14807,7 +14807,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14815,7 +14815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14824,7 +14824,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14836,11 +14836,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14894,28 +14894,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14924,7 +14924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14934,7 +14934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14945,7 +14945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14956,7 +14956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14967,47 +14967,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15017,7 +15017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -15025,14 +15025,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -15040,11 +15040,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15052,11 +15052,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15064,11 +15064,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -15076,7 +15076,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15232,19 +15232,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -15252,19 +15252,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -15272,7 +15272,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -15282,53 +15282,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15336,7 +15336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15345,7 +15345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15355,7 +15355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15365,7 +15365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15375,7 +15375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15385,7 +15385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15396,7 +15396,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15406,7 +15406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15416,7 +15416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15426,7 +15426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15436,7 +15436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15445,7 +15445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15453,7 +15453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15464,7 +15464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15473,7 +15473,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15482,7 +15482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15490,11 +15490,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15504,15 +15504,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15566,92 +15566,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15659,7 +15659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15668,15 +15668,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15684,11 +15684,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15696,22 +15696,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15721,7 +15721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15729,7 +15729,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15851,11 +15851,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15863,11 +15863,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15875,11 +15875,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15887,14 +15887,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15911,7 +15911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15920,7 +15920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15931,7 +15931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15942,7 +15942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15996,23 +15996,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -16020,7 +16020,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -16028,7 +16028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -16036,7 +16036,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -16045,19 +16045,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -16065,11 +16065,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -16079,7 +16079,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -16087,83 +16087,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -16301,11 +16301,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16314,11 +16314,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16329,11 +16329,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16348,7 +16348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16363,7 +16363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16381,7 +16381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16396,66 +16396,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16466,7 +16466,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16474,7 +16474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16483,7 +16483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16491,102 +16491,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16594,40 +16594,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16636,7 +16636,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16645,7 +16645,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16653,7 +16653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16661,7 +16661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16671,7 +16671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16679,7 +16679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16687,7 +16687,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16697,7 +16697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16707,7 +16707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16715,7 +16715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16723,7 +16723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16733,7 +16733,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16741,11 +16741,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16753,7 +16753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16762,7 +16762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16770,11 +16770,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16782,7 +16782,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16791,7 +16791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16800,7 +16800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16809,7 +16809,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16818,7 +16818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16831,7 +16831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16843,7 +16843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16858,31 +16858,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16892,11 +16892,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16906,11 +16906,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16920,11 +16920,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16934,11 +16934,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16948,18 +16948,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16967,18 +16967,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16988,7 +16988,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16998,102 +16998,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -17101,28 +17101,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17130,7 +17130,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -17138,7 +17138,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -17148,31 +17148,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17186,7 +17186,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -17200,15 +17200,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17217,7 +17217,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17225,7 +17225,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -17234,22 +17234,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -17257,40 +17257,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -17298,11 +17298,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17310,11 +17310,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17322,11 +17322,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17334,14 +17334,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17515,7 +17515,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17529,7 +17529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17541,7 +17541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17553,11 +17553,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17565,15 +17565,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17660,7 +17660,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17672,27 +17672,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17702,7 +17702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17710,7 +17710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17718,23 +17718,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17743,7 +17743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17919,82 +17919,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -18003,18 +18003,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -18023,7 +18023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -18032,23 +18032,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18064,7 +18064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -18082,7 +18082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -18095,7 +18095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18108,7 +18108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -18121,7 +18121,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -18131,19 +18131,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18402,7 +18402,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18410,7 +18410,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18419,7 +18419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18428,22 +18428,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18451,15 +18451,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18546,66 +18546,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18614,7 +18614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18622,7 +18622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18630,7 +18630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18711,7 +18711,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18730,7 +18730,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18738,47 +18738,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -19072,51 +19072,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19142,15 +19142,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -19158,18 +19158,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -19177,79 +19177,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -19258,11 +19258,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -19271,7 +19271,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -19280,12 +19280,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -19294,7 +19294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19303,7 +19303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19311,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19323,7 +19323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19335,7 +19335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19345,7 +19345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19355,7 +19355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19366,7 +19366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19380,7 +19380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19392,7 +19392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19403,7 +19403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19416,7 +19416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19428,7 +19428,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19438,7 +19438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19448,31 +19448,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19483,7 +19483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19494,7 +19494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19507,7 +19507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19518,19 +19518,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19538,19 +19538,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19558,7 +19558,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19568,7 +19568,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19576,26 +19576,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19604,7 +19604,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19612,11 +19612,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19624,11 +19624,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19638,7 +19638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19648,7 +19648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19659,7 +19659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19667,7 +19667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -20168,27 +20168,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -20196,51 +20196,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -20253,15 +20253,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -20269,7 +20269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -20277,7 +20277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -20285,15 +20285,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -20301,68 +20301,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20370,7 +20370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20378,25 +20378,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20404,14 +20404,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20419,7 +20419,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20427,7 +20427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20435,14 +20435,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20464,23 +20464,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20488,23 +20488,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20513,19 +20513,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20533,7 +20533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20541,7 +20541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20549,11 +20549,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20561,55 +20561,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20617,7 +20617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20625,25 +20625,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20651,19 +20651,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20671,23 +20671,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20695,33 +20695,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20729,22 +20729,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20794,19 +20794,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20814,15 +20814,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20830,15 +20830,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20846,7 +20846,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20854,21 +20854,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20877,7 +20877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20889,7 +20889,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20901,7 +20901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20913,19 +20913,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20933,33 +20933,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20968,11 +20968,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20982,7 +20982,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20992,7 +20992,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -21002,19 +21002,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -21022,18 +21022,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21042,7 +21042,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21051,33 +21051,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -21101,11 +21101,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -21113,18 +21113,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21132,7 +21132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21140,7 +21140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21148,21 +21148,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21191,23 +21191,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21215,11 +21215,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21228,7 +21228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21237,15 +21237,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -21253,7 +21253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -21261,7 +21261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21270,7 +21270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -21279,7 +21279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -21288,7 +21288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -21297,7 +21297,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -21306,259 +21306,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21566,11 +21566,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21580,7 +21580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21588,14 +21588,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21605,7 +21605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21613,42 +21613,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21657,7 +21657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -22230,11 +22230,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22242,7 +22242,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22250,54 +22250,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22305,27 +22305,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22333,7 +22333,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22342,44 +22342,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22387,34 +22387,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22422,26 +22422,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22449,18 +22449,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22468,38 +22468,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22507,25 +22507,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22533,7 +22533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22541,23 +22541,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22565,26 +22565,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22592,26 +22592,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22619,7 +22619,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22629,7 +22629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22639,7 +22639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22649,7 +22649,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22661,7 +22661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22672,15 +22672,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22688,18 +22688,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22707,7 +22707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22715,28 +22715,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22746,7 +22746,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22756,7 +22756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22766,37 +22766,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22806,66 +22806,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22874,19 +22874,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22895,7 +22895,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22903,7 +22903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22912,7 +22912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22921,15 +22921,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22938,11 +22938,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22951,7 +22951,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22961,7 +22961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22970,7 +22970,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22980,11 +22980,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22992,7 +22992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -23000,7 +23000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -23008,21 +23008,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -23030,7 +23030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23039,7 +23039,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -23049,11 +23049,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23061,7 +23061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23069,28 +23069,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23100,7 +23100,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23110,7 +23110,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23120,7 +23120,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -23130,7 +23130,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -23140,7 +23140,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -23150,14 +23150,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -23166,7 +23166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -23175,34 +23175,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23210,26 +23210,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -23240,7 +23240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -23250,11 +23250,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23262,19 +23262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -23291,19 +23291,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23390,15 +23390,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23406,14 +23406,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23532,18 +23532,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23551,7 +23551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23559,202 +23559,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23762,15 +23762,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23779,50 +23779,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23831,7 +23831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23841,7 +23841,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23849,7 +23849,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23857,7 +23857,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23865,19 +23865,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23886,11 +23886,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23898,81 +23898,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23981,11 +23981,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23993,7 +23993,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -24001,7 +24001,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -24013,109 +24013,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24123,7 +24123,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -24131,20 +24131,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -24152,7 +24152,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -24160,42 +24160,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -24207,14 +24207,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -24224,7 +24224,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24234,7 +24234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -24244,7 +24244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -24256,7 +24256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24267,7 +24267,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24281,7 +24281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -24290,7 +24290,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -24300,7 +24300,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24310,7 +24310,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24321,7 +24321,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24335,7 +24335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24344,7 +24344,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24353,11 +24353,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24366,7 +24366,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24375,7 +24375,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24384,15 +24384,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24401,7 +24401,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24410,15 +24410,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24427,7 +24427,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24436,23 +24436,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24461,7 +24461,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24470,15 +24470,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24487,7 +24487,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24496,15 +24496,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24513,7 +24513,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24522,15 +24522,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24539,7 +24539,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24548,21 +24548,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24571,7 +24571,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24580,7 +24580,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24592,7 +24592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24604,7 +24604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24613,7 +24613,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24622,15 +24622,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24639,7 +24639,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24648,15 +24648,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24665,7 +24665,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24674,7 +24674,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24686,7 +24686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24698,7 +24698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24707,7 +24707,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24716,15 +24716,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24733,7 +24733,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24742,15 +24742,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24759,7 +24759,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24768,7 +24768,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24780,7 +24780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24792,7 +24792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24801,7 +24801,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24810,15 +24810,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24827,7 +24827,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24836,15 +24836,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24853,7 +24853,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24862,7 +24862,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24874,7 +24874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24886,7 +24886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24895,7 +24895,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24904,15 +24904,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24924,7 +24924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24936,7 +24936,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24948,7 +24948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24960,7 +24960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24969,7 +24969,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24981,7 +24981,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24993,7 +24993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -25005,7 +25005,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -25014,7 +25014,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -25026,7 +25026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -25039,7 +25039,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -25053,7 +25053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -25061,7 +25061,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -25069,7 +25069,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -25078,11 +25078,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -25090,27 +25090,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25120,7 +25120,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -25128,7 +25128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -25143,74 +25143,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25311,19 +25311,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25388,11 +25388,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25479,11 +25479,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25491,42 +25491,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25601,15 +25601,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25622,7 +25622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25637,18 +25637,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25657,14 +25657,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25673,7 +25673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25684,7 +25684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25693,7 +25693,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25705,7 +25705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25717,18 +25717,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25736,14 +25736,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25751,7 +25751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25765,7 +25765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25780,7 +25780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25793,7 +25793,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25808,7 +25808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27516,15 +27516,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27532,26 +27532,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27559,14 +27559,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27798,15 +27798,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27814,26 +27814,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27841,26 +27841,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27868,29 +27868,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27898,19 +27898,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27918,18 +27918,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27937,7 +27937,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27945,15 +27945,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27961,26 +27961,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27988,22 +27988,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -28011,14 +28011,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -28026,7 +28026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -28034,14 +28034,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28049,15 +28049,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28065,33 +28065,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28099,26 +28099,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28126,26 +28126,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28153,26 +28153,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28180,26 +28180,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28207,26 +28207,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28234,26 +28234,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28261,26 +28261,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28288,26 +28288,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28315,38 +28315,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28354,26 +28354,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28381,70 +28381,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28455,7 +28455,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28463,7 +28463,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28473,7 +28473,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28571,7 +28571,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28582,11 +28582,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28595,7 +28595,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28604,7 +28604,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28613,7 +28613,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28622,7 +28622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28631,7 +28631,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28640,7 +28640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28649,67 +28649,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28718,14 +28718,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28733,7 +28733,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28743,7 +28743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28752,7 +28752,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28761,7 +28761,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28770,7 +28770,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28780,11 +28780,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28792,70 +28792,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28873,43 +28873,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28919,7 +28919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28928,7 +28928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28937,7 +28937,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28945,11 +28945,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -29015,119 +29015,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29135,7 +29135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -29143,15 +29143,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -29159,220 +29159,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29385,7 +29385,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29398,71 +29398,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29470,7 +29470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29478,7 +29478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29486,7 +29486,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29494,26 +29494,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29521,7 +29521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29529,7 +29529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29539,7 +29539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29549,19 +29549,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29569,7 +29569,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29577,7 +29577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29586,7 +29586,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29595,7 +29595,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29603,7 +29603,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29611,7 +29611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29619,7 +29619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29627,7 +29627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29635,7 +29635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29643,7 +29643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29651,7 +29651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29659,29 +29659,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29770,18 +29770,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29806,156 +29806,156 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ciphersuites"]
     pub fn SSL_set_ciphersuites(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29963,11 +29963,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29976,23 +29976,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -30005,7 +30005,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -30014,7 +30014,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -30023,27 +30023,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30051,7 +30051,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -30059,7 +30059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -30067,29 +30067,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -30097,25 +30097,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30123,7 +30123,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -30131,7 +30131,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -30139,22 +30139,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -30162,19 +30162,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -30182,7 +30182,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -30190,19 +30190,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -30210,34 +30210,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -30245,7 +30245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -30253,44 +30253,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -30299,7 +30299,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30307,7 +30307,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30316,13 +30316,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30336,7 +30336,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30349,11 +30349,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30361,7 +30361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30369,7 +30369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30461,14 +30461,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30476,15 +30476,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30492,7 +30492,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30500,29 +30500,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30530,11 +30530,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30542,7 +30542,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30550,21 +30550,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30577,7 +30577,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30594,7 +30594,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30604,7 +30604,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30614,15 +30614,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30633,7 +30633,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30644,83 +30644,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30728,19 +30728,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30753,51 +30753,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30805,7 +30805,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30813,87 +30813,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30906,18 +30906,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30925,7 +30925,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30933,7 +30933,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30950,7 +30950,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30958,11 +30958,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30972,7 +30972,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30980,7 +30980,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -31001,7 +31001,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -31010,7 +31010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31025,7 +31025,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31042,7 +31042,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -31050,7 +31050,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -31061,29 +31061,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -31160,29 +31160,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31198,7 +31198,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31214,7 +31214,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31228,7 +31228,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31242,29 +31242,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -31273,7 +31273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31386,22 +31386,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31410,25 +31410,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31436,7 +31436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31444,11 +31444,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31456,35 +31456,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31506,21 +31506,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31528,7 +31528,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31536,7 +31536,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31544,7 +31544,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31555,19 +31555,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31577,12 +31577,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31590,34 +31590,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31625,14 +31625,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31642,7 +31642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31650,14 +31650,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31667,7 +31667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31675,14 +31675,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31692,7 +31692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31701,11 +31701,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31713,26 +31713,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31742,11 +31742,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31754,7 +31754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31771,11 +31771,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31792,11 +31792,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31805,7 +31805,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31813,14 +31813,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31830,46 +31830,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -32063,7 +32063,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -32072,7 +32072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32081,7 +32081,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32090,19 +32090,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32115,7 +32115,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -32127,7 +32127,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32140,7 +32140,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -32152,77 +32152,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -32230,11 +32230,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -32245,126 +32245,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32377,7 +32377,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32390,98 +32390,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32489,7 +32489,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32501,11 +32501,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32513,61 +32513,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32580,7 +32580,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32593,7 +32593,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32601,7 +32601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32609,25 +32609,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32707,26 +32707,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32739,11 +32739,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32751,7 +32751,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32759,15 +32759,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32777,42 +32777,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32820,33 +32820,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32854,11 +32854,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32870,18 +32870,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -32897,15 +32897,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -4321,7 +4321,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4329,7 +4329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4337,15 +4337,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4357,7 +4357,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4366,7 +4366,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4377,7 +4377,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4388,7 +4388,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4400,7 +4400,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4410,7 +4410,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4420,7 +4420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4431,7 +4431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4659,27 +4659,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4687,29 +4687,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4717,7 +4717,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4725,38 +4725,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4765,18 +4765,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4785,18 +4785,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -4805,7 +4805,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -4813,11 +4813,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -4828,30 +4828,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -4890,30 +4890,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -4923,15 +4923,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -5059,27 +5059,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -5087,11 +5087,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -5099,22 +5099,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -5123,7 +5123,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -5132,35 +5132,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -5170,7 +5170,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -5230,7 +5230,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -5286,19 +5286,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5311,7 +5311,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5325,7 +5325,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5336,29 +5336,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5414,7 +5414,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5425,7 +5425,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5438,7 +5438,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5450,7 +5450,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5459,7 +5459,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5470,7 +5470,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5497,23 +5497,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -5521,7 +5521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -5529,7 +5529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5537,7 +5537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -5545,15 +5545,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5562,7 +5562,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5570,7 +5570,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5579,67 +5579,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -5665,7 +5665,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -5673,68 +5673,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -5742,7 +5742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -5750,7 +5750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -5759,11 +5759,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -5772,15 +5772,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -5788,11 +5788,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -5800,22 +5800,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -5823,30 +5823,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -5854,89 +5854,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -5945,34 +5945,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -5981,13 +5981,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -5996,13 +5996,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6015,7 +6015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6028,7 +6028,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -6041,7 +6041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6053,7 +6053,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -6067,7 +6067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6080,7 +6080,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -6093,7 +6093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6105,23 +6105,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -6131,7 +6131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -6139,37 +6139,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -6181,7 +6181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -6551,193 +6551,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6746,15 +6746,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -6764,11 +6764,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -6776,47 +6776,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6824,11 +6824,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6836,43 +6836,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -6881,7 +6881,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6891,7 +6891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6900,7 +6900,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6910,7 +6910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6919,7 +6919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6929,7 +6929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6938,7 +6938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6948,7 +6948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6957,7 +6957,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6966,7 +6966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6974,7 +6974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -6983,7 +6983,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -6992,7 +6992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7001,11 +7001,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7013,7 +7013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -7073,15 +7073,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -7095,7 +7095,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -7103,11 +7103,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7122,7 +7122,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -7132,7 +7132,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -7143,7 +7143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7153,7 +7153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -7162,7 +7162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7171,7 +7171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7180,7 +7180,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7190,7 +7190,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -7200,23 +7200,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7225,7 +7225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7234,7 +7234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7244,7 +7244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7253,7 +7253,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7263,7 +7263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7274,7 +7274,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7285,15 +7285,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -7304,7 +7304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -7317,11 +7317,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -7329,7 +7329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -7337,7 +7337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -7485,15 +7485,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -7517,15 +7517,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7534,7 +7534,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -7542,14 +7542,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -7557,7 +7557,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -7565,7 +7565,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -7573,7 +7573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -7581,14 +7581,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -7596,7 +7596,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -7604,22 +7604,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -7695,54 +7695,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -7750,7 +7750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -7758,79 +7758,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -7838,7 +7838,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -7846,7 +7846,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -7854,7 +7854,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -7862,7 +7862,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -7870,7 +7870,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -7878,7 +7878,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -7886,7 +7886,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -7894,7 +7894,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -7902,117 +7902,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -8020,14 +8020,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8037,7 +8037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -8049,7 +8049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -8059,7 +8059,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -8069,15 +8069,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8085,26 +8085,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -8112,23 +8112,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8136,14 +8136,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -8151,25 +8151,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -8177,7 +8177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -8185,14 +8185,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -8221,19 +8221,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -8241,11 +8241,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -8253,54 +8253,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -8308,59 +8308,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -8368,23 +8368,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -8393,26 +8393,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -8420,29 +8420,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -8451,22 +8451,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -8474,15 +8474,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -8491,15 +8491,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -8508,41 +8508,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -8550,11 +8550,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8579,7 +8579,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -8589,11 +8589,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8601,11 +8601,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -8613,7 +8613,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8947,15 +8947,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -8963,19 +8963,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -8983,7 +8983,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -8991,12 +8991,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9004,14 +9004,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9019,33 +9019,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -9053,7 +9053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -9061,19 +9061,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -9081,7 +9081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -9089,7 +9089,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -9099,7 +9099,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -9109,11 +9109,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -9121,33 +9121,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9155,34 +9155,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -9792,7 +9792,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9817,19 +9817,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -9839,19 +9839,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9861,7 +9861,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9869,11 +9869,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9883,7 +9883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -9891,7 +9891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -10101,11 +10101,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -10113,11 +10113,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -10172,19 +10172,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10193,7 +10193,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -10254,23 +10254,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -10278,82 +10278,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10361,7 +10361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10369,11 +10369,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10381,7 +10381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10390,7 +10390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10401,22 +10401,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10425,7 +10425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -10434,7 +10434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -10443,7 +10443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -10452,33 +10452,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10486,7 +10486,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -10494,7 +10494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -10801,23 +10801,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -10825,40 +10825,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -10866,15 +10866,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -10882,55 +10882,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -10938,11 +10938,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -10950,7 +10950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -10958,11 +10958,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -10970,11 +10970,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -10985,114 +10985,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11103,7 +11103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11113,7 +11113,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11123,7 +11123,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11133,7 +11133,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11141,7 +11141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11151,7 +11151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11159,7 +11159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11169,7 +11169,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11177,47 +11177,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -11226,45 +11226,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -11277,23 +11277,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11303,7 +11303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11312,7 +11312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -11321,7 +11321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11329,7 +11329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11337,7 +11337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11345,7 +11345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -11354,118 +11354,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -11702,7 +11702,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -11712,19 +11712,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -11734,15 +11734,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -11837,15 +11837,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -11853,7 +11853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -11861,14 +11861,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -11876,7 +11876,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -11884,23 +11884,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11908,15 +11908,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12003,11 +12003,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12015,19 +12015,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12035,19 +12035,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -12145,11 +12145,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12157,19 +12157,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12177,15 +12177,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12283,11 +12283,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12295,34 +12295,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -12330,34 +12330,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12365,7 +12365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12374,7 +12374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -12383,7 +12383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12391,7 +12391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -12399,21 +12399,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12421,7 +12421,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -12429,7 +12429,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -12437,7 +12437,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -12446,7 +12446,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -12454,11 +12454,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -12485,51 +12485,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -12539,70 +12539,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -12610,15 +12610,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -12627,7 +12627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -12636,7 +12636,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -12647,7 +12647,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -12657,11 +12657,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -12672,7 +12672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -12745,15 +12745,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -12762,7 +12762,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12773,7 +12773,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -12784,7 +12784,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12797,7 +12797,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -12809,7 +12809,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -12818,7 +12818,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -12827,43 +12827,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -12871,7 +12871,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -12879,7 +12879,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -12888,7 +12888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -12897,40 +12897,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -12939,11 +12939,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -12951,7 +12951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -12962,19 +12962,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -12982,19 +12982,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13009,7 +13009,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13017,14 +13017,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13032,114 +13032,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13147,11 +13147,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13159,7 +13159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13167,7 +13167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13175,7 +13175,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13186,75 +13186,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13262,19 +13262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13366,19 +13366,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -13386,11 +13386,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -13398,15 +13398,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -13452,43 +13452,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13496,7 +13496,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13505,7 +13505,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13513,7 +13513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13522,7 +13522,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13534,11 +13534,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13592,28 +13592,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -13622,7 +13622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13632,7 +13632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13643,7 +13643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -13654,7 +13654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -13665,47 +13665,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -13715,7 +13715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -13723,14 +13723,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -13738,11 +13738,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13750,11 +13750,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13762,11 +13762,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -13774,7 +13774,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13930,19 +13930,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -13950,19 +13950,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -13970,7 +13970,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -13980,53 +13980,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14034,7 +14034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14043,7 +14043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14053,7 +14053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14063,7 +14063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14073,7 +14073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14083,7 +14083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14094,7 +14094,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14104,7 +14104,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14114,7 +14114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14124,7 +14124,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14134,7 +14134,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14143,7 +14143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14151,7 +14151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14162,7 +14162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14171,7 +14171,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14180,7 +14180,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14188,11 +14188,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14202,15 +14202,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -14264,92 +14264,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14357,7 +14357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14366,15 +14366,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14382,11 +14382,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14394,22 +14394,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14419,7 +14419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14427,7 +14427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14549,11 +14549,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14561,11 +14561,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14573,11 +14573,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14585,14 +14585,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14609,7 +14609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14618,7 +14618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14629,7 +14629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14640,7 +14640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -14694,23 +14694,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -14718,7 +14718,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -14726,7 +14726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -14734,7 +14734,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14743,19 +14743,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -14763,11 +14763,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -14777,7 +14777,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -14785,83 +14785,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -14999,11 +14999,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15012,11 +15012,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15027,11 +15027,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15046,7 +15046,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15061,7 +15061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15079,7 +15079,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15094,66 +15094,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15164,7 +15164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15172,7 +15172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15181,7 +15181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15189,102 +15189,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -15292,40 +15292,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15334,7 +15334,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15343,7 +15343,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15351,7 +15351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15359,7 +15359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15369,7 +15369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15377,7 +15377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15385,7 +15385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15395,7 +15395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15405,7 +15405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15413,7 +15413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15421,7 +15421,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15431,7 +15431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15439,11 +15439,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15451,7 +15451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15460,7 +15460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15468,11 +15468,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15480,7 +15480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15489,7 +15489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15498,7 +15498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15507,7 +15507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -15516,7 +15516,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15529,7 +15529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15541,7 +15541,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -15556,31 +15556,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -15590,11 +15590,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -15604,11 +15604,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15618,11 +15618,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15632,11 +15632,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -15646,18 +15646,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -15665,18 +15665,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -15686,7 +15686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -15696,102 +15696,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -15799,28 +15799,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -15828,7 +15828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -15836,7 +15836,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -15846,31 +15846,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -15884,7 +15884,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -15898,15 +15898,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -15915,7 +15915,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -15923,7 +15923,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -15932,22 +15932,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -15955,40 +15955,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -15996,11 +15996,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16008,11 +16008,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16020,11 +16020,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16032,14 +16032,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -16213,7 +16213,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16227,7 +16227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16239,7 +16239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16251,11 +16251,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16263,15 +16263,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16358,7 +16358,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16370,27 +16370,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16400,7 +16400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16408,7 +16408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16416,23 +16416,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16441,7 +16441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -16617,82 +16617,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -16701,18 +16701,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16721,7 +16721,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -16730,23 +16730,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16762,7 +16762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -16780,7 +16780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -16793,7 +16793,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -16806,7 +16806,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -16819,7 +16819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -16829,19 +16829,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17100,7 +17100,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17108,7 +17108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17117,7 +17117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17126,22 +17126,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17149,15 +17149,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17244,66 +17244,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -17312,7 +17312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -17320,7 +17320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -17328,7 +17328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -17409,7 +17409,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -17428,7 +17428,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17436,47 +17436,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -17770,51 +17770,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -17840,15 +17840,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -17856,18 +17856,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -17875,79 +17875,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -17956,11 +17956,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -17969,7 +17969,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -17978,12 +17978,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -17992,7 +17992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18001,7 +18001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18009,7 +18009,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18021,7 +18021,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18033,7 +18033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18043,7 +18043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18053,7 +18053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18064,7 +18064,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18078,7 +18078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18090,7 +18090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18101,7 +18101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18114,7 +18114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18126,7 +18126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18136,7 +18136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18146,31 +18146,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18181,7 +18181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18192,7 +18192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18205,7 +18205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18216,19 +18216,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18236,19 +18236,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -18256,7 +18256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -18266,7 +18266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -18274,26 +18274,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -18302,7 +18302,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18310,11 +18310,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -18322,11 +18322,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18336,7 +18336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18346,7 +18346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -18357,7 +18357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -18365,7 +18365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -18866,27 +18866,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -18894,51 +18894,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -18951,15 +18951,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -18967,7 +18967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -18975,7 +18975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -18983,15 +18983,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -18999,68 +18999,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19068,7 +19068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19076,25 +19076,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19102,14 +19102,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -19117,7 +19117,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -19125,7 +19125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -19133,14 +19133,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -19162,23 +19162,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19186,23 +19186,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -19211,19 +19211,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19231,7 +19231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19239,7 +19239,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19247,11 +19247,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19259,55 +19259,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19315,7 +19315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19323,25 +19323,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19349,19 +19349,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -19369,23 +19369,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19393,33 +19393,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -19427,22 +19427,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -19492,19 +19492,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -19512,15 +19512,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -19528,15 +19528,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19544,7 +19544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19552,21 +19552,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -19575,7 +19575,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -19587,7 +19587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -19599,7 +19599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -19611,19 +19611,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -19631,33 +19631,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -19666,11 +19666,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -19680,7 +19680,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -19690,7 +19690,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -19700,19 +19700,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -19720,18 +19720,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19740,7 +19740,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19749,33 +19749,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -19799,11 +19799,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -19811,18 +19811,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -19830,7 +19830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -19838,7 +19838,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -19846,21 +19846,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -19889,23 +19889,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -19913,11 +19913,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -19926,7 +19926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -19935,15 +19935,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -19951,7 +19951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -19959,7 +19959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -19968,7 +19968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -19977,7 +19977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -19986,7 +19986,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -19995,7 +19995,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20004,259 +20004,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -20264,11 +20264,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20278,7 +20278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -20286,14 +20286,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -20303,7 +20303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -20311,42 +20311,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20355,7 +20355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20928,11 +20928,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -20940,7 +20940,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -20948,54 +20948,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21003,27 +21003,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -21031,7 +21031,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -21040,44 +21040,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21085,34 +21085,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21120,26 +21120,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21147,18 +21147,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21166,38 +21166,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21205,25 +21205,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21231,7 +21231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -21239,23 +21239,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21263,26 +21263,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21290,26 +21290,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -21317,7 +21317,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -21327,7 +21327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -21337,7 +21337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -21347,7 +21347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21359,7 +21359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -21370,15 +21370,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -21386,18 +21386,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21405,7 +21405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21413,28 +21413,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -21444,7 +21444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -21454,7 +21454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -21464,37 +21464,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -21504,66 +21504,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -21572,19 +21572,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -21593,7 +21593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -21601,7 +21601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -21610,7 +21610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -21619,15 +21619,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -21636,11 +21636,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -21649,7 +21649,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -21659,7 +21659,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21668,7 +21668,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -21678,11 +21678,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21690,7 +21690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -21698,7 +21698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -21706,21 +21706,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -21728,7 +21728,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21737,7 +21737,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -21747,11 +21747,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21759,7 +21759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21767,28 +21767,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21798,7 +21798,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21808,7 +21808,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21818,7 +21818,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21828,7 +21828,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21838,7 +21838,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21848,14 +21848,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21864,7 +21864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21873,34 +21873,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -21908,26 +21908,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -21938,7 +21938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -21948,11 +21948,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -21960,19 +21960,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -21989,19 +21989,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22088,15 +22088,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22104,14 +22104,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -22230,18 +22230,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22249,7 +22249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -22257,202 +22257,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22460,15 +22460,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -22477,50 +22477,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -22529,7 +22529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -22539,7 +22539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22547,7 +22547,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22555,7 +22555,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -22563,19 +22563,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -22584,11 +22584,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -22596,81 +22596,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -22679,11 +22679,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22691,7 +22691,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -22699,7 +22699,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -22711,109 +22711,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -22821,7 +22821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -22829,20 +22829,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -22850,7 +22850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -22858,42 +22858,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -22905,14 +22905,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -22922,7 +22922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -22932,7 +22932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -22942,7 +22942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -22954,7 +22954,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -22965,7 +22965,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -22979,7 +22979,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -22988,7 +22988,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -22998,7 +22998,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -23008,7 +23008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23019,7 +23019,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23033,7 +23033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -23042,7 +23042,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -23051,11 +23051,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -23064,7 +23064,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23073,7 +23073,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23082,15 +23082,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -23099,7 +23099,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -23108,15 +23108,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -23125,7 +23125,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -23134,23 +23134,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -23159,7 +23159,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -23168,15 +23168,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -23185,7 +23185,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -23194,15 +23194,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -23211,7 +23211,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -23220,15 +23220,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23237,7 +23237,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -23246,21 +23246,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23269,7 +23269,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23278,7 +23278,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -23290,7 +23290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -23302,7 +23302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23311,7 +23311,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23320,15 +23320,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -23337,7 +23337,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -23346,15 +23346,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23363,7 +23363,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23372,7 +23372,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -23384,7 +23384,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -23396,7 +23396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23405,7 +23405,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23414,15 +23414,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -23431,7 +23431,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -23440,15 +23440,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23457,7 +23457,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23466,7 +23466,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -23478,7 +23478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -23490,7 +23490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -23499,7 +23499,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -23508,15 +23508,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -23525,7 +23525,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -23534,15 +23534,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23551,7 +23551,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23560,7 +23560,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23572,7 +23572,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23584,7 +23584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23593,7 +23593,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23602,15 +23602,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23622,7 +23622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -23634,7 +23634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23646,7 +23646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -23658,7 +23658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -23667,7 +23667,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23679,7 +23679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23691,7 +23691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23703,7 +23703,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -23712,7 +23712,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -23724,7 +23724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -23737,7 +23737,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -23751,7 +23751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -23759,7 +23759,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -23767,7 +23767,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -23776,11 +23776,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -23788,27 +23788,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -23818,7 +23818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -23826,7 +23826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -23841,74 +23841,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24009,19 +24009,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -24086,11 +24086,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -24177,11 +24177,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -24189,42 +24189,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -24299,15 +24299,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24320,7 +24320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -24335,18 +24335,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24355,14 +24355,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24371,7 +24371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24382,7 +24382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -24391,7 +24391,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -24403,7 +24403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -24415,18 +24415,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24434,14 +24434,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -24449,7 +24449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24463,7 +24463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -24478,7 +24478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24491,7 +24491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -24506,7 +24506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -26214,15 +26214,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26230,26 +26230,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26257,14 +26257,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -26496,15 +26496,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26512,26 +26512,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26539,26 +26539,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26566,29 +26566,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -26596,19 +26596,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26616,18 +26616,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -26635,7 +26635,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26643,15 +26643,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26659,26 +26659,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26686,22 +26686,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -26709,14 +26709,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -26724,7 +26724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -26732,14 +26732,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -26747,15 +26747,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26763,33 +26763,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26797,26 +26797,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26824,26 +26824,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26851,26 +26851,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26878,26 +26878,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26905,26 +26905,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26932,26 +26932,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26959,26 +26959,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26986,26 +26986,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27013,38 +27013,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27052,26 +27052,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27079,70 +27079,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27153,7 +27153,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27161,7 +27161,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -27171,7 +27171,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -27269,7 +27269,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -27280,11 +27280,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27293,7 +27293,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27302,7 +27302,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -27311,7 +27311,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27320,7 +27320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27329,7 +27329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27338,7 +27338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -27347,67 +27347,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27416,14 +27416,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -27431,7 +27431,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -27441,7 +27441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -27450,7 +27450,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -27459,7 +27459,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -27468,7 +27468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -27478,11 +27478,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -27490,70 +27490,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -27571,43 +27571,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27617,7 +27617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -27626,7 +27626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -27635,7 +27635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -27643,15 +27643,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -27667,15 +27667,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto_ssl.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto_ssl.rs
@@ -111,7 +111,7 @@ pub const AWSLC_VERSION_NAME: &[u8; 7] = b"AWS-LC\0";
 pub const OPENSSL_VERSION_NUMBER: i32 = 269488255;
 pub const SSLEAY_VERSION_NUMBER: i32 = 269488255;
 pub const AWSLC_API_VERSION: i32 = 20;
-pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.13\0";
+pub const AWSLC_VERSION_NUMBER_STRING: &[u8; 7] = b"2.0.14\0";
 pub const AES_ENCRYPT: i32 = 1;
 pub const AES_DECRYPT: i32 = 0;
 pub const AES_MAXNR: i32 = 14;
@@ -3540,7 +3540,7 @@ pub const RIPEMD160_CBLOCK: i32 = 64;
 pub const RIPEMD160_LBLOCK: i32 = 16;
 pub const RIPEMD160_DIGEST_LENGTH: i32 = 20;
 pub const AWSLC_MODE_STRING: &[u8; 8] = b"AWS-LC \0";
-pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.13\0";
+pub const AWSLC_VERSION_STRING: &[u8; 14] = b"AWS-LC 2.0.14\0";
 pub const TRUST_TOKEN_MAX_PRIVATE_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_MAX_PUBLIC_KEY_SIZE: i32 = 512;
 pub const TRUST_TOKEN_R_KEYGEN_FAILURE: i32 = 100;
@@ -5313,7 +5313,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5321,7 +5321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -5329,15 +5329,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5349,7 +5349,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5358,7 +5358,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5369,7 +5369,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5380,7 +5380,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -5392,7 +5392,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5402,7 +5402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -5412,7 +5412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5423,7 +5423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5651,27 +5651,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5679,29 +5679,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5709,7 +5709,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5717,38 +5717,38 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5757,18 +5757,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5777,18 +5777,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -5797,7 +5797,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -5805,11 +5805,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -5820,30 +5820,30 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 pub const ERR_LIB_NONE: _bindgen_ty_1 = 1;
@@ -5882,30 +5882,30 @@ pub const ERR_LIB_USER: _bindgen_ty_1 = 33;
 pub const ERR_NUM_LIBS: _bindgen_ty_1 = 34;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -5915,15 +5915,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6051,27 +6051,27 @@ impl Default for stack_st {
 }
 pub type _STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new"]
     pub fn sk_new(comp: OPENSSL_sk_cmp_func) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_new_null"]
     pub fn sk_new_null() -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_num"]
     pub fn sk_num(sk: *const _STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_zero"]
     pub fn sk_zero(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_value"]
     pub fn sk_value(sk: *const _STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set"]
     pub fn sk_set(
         sk: *mut _STACK,
         i: usize,
@@ -6079,11 +6079,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_free"]
     pub fn sk_free(sk: *mut _STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free_ex"]
     pub fn sk_pop_free_ex(
         sk: *mut _STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6091,22 +6091,22 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_insert"]
     pub fn sk_insert(sk: *mut _STACK, p: *mut ::std::os::raw::c_void, where_: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete"]
     pub fn sk_delete(sk: *mut _STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_ptr"]
     pub fn sk_delete_ptr(
         sk: *mut _STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_delete_if"]
     pub fn sk_delete_if(
         sk: *mut _STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6115,7 +6115,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_find"]
     pub fn sk_find(
         sk: *const _STACK,
         out_index: *mut usize,
@@ -6124,35 +6124,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_shift"]
     pub fn sk_shift(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_push"]
     pub fn sk_push(sk: *mut _STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop"]
     pub fn sk_pop(sk: *mut _STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_dup"]
     pub fn sk_dup(sk: *const _STACK) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_sort"]
     pub fn sk_sort(sk: *mut _STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_is_sorted"]
     pub fn sk_is_sorted(sk: *const _STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_set_cmp_func"]
     pub fn sk_set_cmp_func(sk: *mut _STACK, comp: OPENSSL_sk_cmp_func) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_deep_copy"]
     pub fn sk_deep_copy(
         sk: *const _STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6162,7 +6162,7 @@ extern "C" {
     ) -> *mut _STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut _STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6222,7 +6222,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6278,19 +6278,19 @@ impl Default for crypto_ex_data_st {
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6303,7 +6303,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6317,7 +6317,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6328,29 +6328,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6406,7 +6406,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6417,7 +6417,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6430,7 +6430,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6442,7 +6442,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6451,7 +6451,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6462,7 +6462,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6489,23 +6489,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6513,7 +6513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6521,7 +6521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6529,7 +6529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6537,15 +6537,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6554,7 +6554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6562,7 +6562,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6571,67 +6571,67 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6657,7 +6657,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6665,68 +6665,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6734,7 +6734,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6742,7 +6742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6751,11 +6751,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6764,15 +6764,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6780,11 +6780,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6792,22 +6792,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6815,30 +6815,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6846,89 +6846,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6937,34 +6937,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6973,13 +6973,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6988,13 +6988,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7007,7 +7007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7020,7 +7020,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7033,7 +7033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7045,7 +7045,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7059,7 +7059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7072,7 +7072,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7085,7 +7085,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7097,23 +7097,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7123,7 +7123,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7131,37 +7131,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7173,7 +7173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7543,193 +7543,193 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7738,15 +7738,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7756,11 +7756,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7768,47 +7768,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7816,11 +7816,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7828,43 +7828,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7873,7 +7873,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7883,7 +7883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7892,7 +7892,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7902,7 +7902,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7911,7 +7911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7921,7 +7921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7930,7 +7930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7940,7 +7940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7949,7 +7949,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7958,7 +7958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7966,7 +7966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7975,7 +7975,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7984,7 +7984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7993,11 +7993,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8005,7 +8005,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8065,15 +8065,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8087,7 +8087,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8095,11 +8095,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8114,7 +8114,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8124,7 +8124,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8135,7 +8135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8145,7 +8145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8154,7 +8154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8163,7 +8163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8172,7 +8172,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8182,7 +8182,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8192,23 +8192,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8217,7 +8217,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8226,7 +8226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8236,7 +8236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8245,7 +8245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8255,7 +8255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8266,7 +8266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8277,15 +8277,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8296,7 +8296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8309,11 +8309,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8321,7 +8321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8329,7 +8329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 #[repr(C)]
@@ -8477,15 +8477,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8509,15 +8509,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8526,7 +8526,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8534,14 +8534,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8549,7 +8549,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8557,7 +8557,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8565,7 +8565,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8573,14 +8573,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8588,7 +8588,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8596,22 +8596,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8687,54 +8687,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8742,7 +8742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8750,79 +8750,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8830,7 +8830,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8838,7 +8838,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8846,7 +8846,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8854,7 +8854,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8862,7 +8862,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8870,7 +8870,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8878,7 +8878,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8886,7 +8886,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8894,117 +8894,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9012,14 +9012,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9029,7 +9029,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9041,7 +9041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9051,7 +9051,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9061,15 +9061,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9077,26 +9077,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9104,23 +9104,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9128,14 +9128,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9143,25 +9143,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9169,7 +9169,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9177,14 +9177,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9213,19 +9213,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9233,11 +9233,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9245,54 +9245,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9300,59 +9300,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9360,23 +9360,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9385,26 +9385,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9412,29 +9412,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9443,22 +9443,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9466,15 +9466,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9483,15 +9483,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9500,41 +9500,41 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9542,11 +9542,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9571,7 +9571,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9581,11 +9581,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9593,11 +9593,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(a: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9605,7 +9605,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9939,15 +9939,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -9955,19 +9955,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9975,7 +9975,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -9983,12 +9983,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -9996,14 +9996,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10011,33 +10011,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10045,7 +10045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10053,19 +10053,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10073,7 +10073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10081,7 +10081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10091,7 +10091,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10101,11 +10101,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10113,33 +10113,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10147,34 +10147,34 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10784,7 +10784,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10809,19 +10809,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10831,19 +10831,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10853,7 +10853,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10861,11 +10861,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10875,7 +10875,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10883,7 +10883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11093,11 +11093,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11105,11 +11105,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11164,19 +11164,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11185,7 +11185,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11246,23 +11246,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11270,82 +11270,82 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11353,7 +11353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11361,11 +11361,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11373,7 +11373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11382,7 +11382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11393,22 +11393,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11417,7 +11417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11426,7 +11426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11435,7 +11435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11444,33 +11444,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11478,7 +11478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11486,7 +11486,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11793,23 +11793,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11817,40 +11817,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11858,15 +11858,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11874,55 +11874,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11930,11 +11930,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11942,7 +11942,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -11950,11 +11950,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -11962,11 +11962,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -11977,114 +11977,114 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12095,7 +12095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12105,7 +12105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12115,7 +12115,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12125,7 +12125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12133,7 +12133,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12143,7 +12143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12151,7 +12151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12161,7 +12161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12169,47 +12169,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12218,45 +12218,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12269,23 +12269,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12295,7 +12295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12304,7 +12304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12313,7 +12313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12321,7 +12321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12329,7 +12329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12337,7 +12337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12346,118 +12346,118 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 #[repr(C)]
@@ -12694,7 +12694,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12704,19 +12704,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12726,15 +12726,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12829,15 +12829,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12845,7 +12845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12853,14 +12853,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12868,7 +12868,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12876,23 +12876,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -12900,15 +12900,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -12995,11 +12995,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13007,19 +13007,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13027,19 +13027,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -13137,11 +13137,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13149,19 +13149,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13169,15 +13169,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -13275,11 +13275,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13287,34 +13287,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -13322,34 +13322,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13357,7 +13357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13366,7 +13366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -13375,7 +13375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13383,7 +13383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -13391,21 +13391,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13413,7 +13413,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -13421,7 +13421,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -13429,7 +13429,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -13438,7 +13438,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -13446,11 +13446,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -13477,51 +13477,51 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BORINGSSL_integrity_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BORINGSSL_integrity_test"]
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -13531,70 +13531,70 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13602,15 +13602,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13619,7 +13619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13628,7 +13628,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13639,7 +13639,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13649,11 +13649,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13664,7 +13664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13737,15 +13737,15 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_key"]
     pub fn DES_set_key(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13754,7 +13754,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13765,7 +13765,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13776,7 +13776,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13789,7 +13789,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13801,7 +13801,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_decrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_decrypt3"]
     pub fn DES_decrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13810,7 +13810,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DES_encrypt3"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DES_encrypt3"]
     pub fn DES_encrypt3(
         data: *mut u32,
         ks1: *const DES_key_schedule,
@@ -13819,43 +13819,43 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13863,7 +13863,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13871,7 +13871,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13880,7 +13880,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13889,40 +13889,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13931,11 +13931,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13943,7 +13943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13954,19 +13954,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13974,19 +13974,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -14001,7 +14001,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -14009,14 +14009,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -14024,114 +14024,114 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -14139,11 +14139,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -14151,7 +14151,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14159,7 +14159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -14167,7 +14167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -14178,75 +14178,75 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14254,19 +14254,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14358,19 +14358,19 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_RSA_method"]
     pub fn ENGINE_set_RSA_method(
         engine: *mut ENGINE,
         method: *const RSA_METHOD,
@@ -14378,11 +14378,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_RSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_RSA_method"]
     pub fn ENGINE_get_RSA_method(engine: *const ENGINE) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_set_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_set_ECDSA_method"]
     pub fn ENGINE_set_ECDSA_method(
         engine: *mut ENGINE,
         method: *const ECDSA_METHOD,
@@ -14390,15 +14390,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ENGINE_get_ECDSA_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ENGINE_get_ECDSA_method"]
     pub fn ENGINE_get_ECDSA_method(engine: *const ENGINE) -> *mut ECDSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_ref"]
     pub fn METHOD_ref(method: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_METHOD_unref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_METHOD_unref"]
     pub fn METHOD_unref(method: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -14444,43 +14444,43 @@ fn bindgen_test_layout_openssl_method_common_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14488,7 +14488,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14497,7 +14497,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14505,7 +14505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14514,7 +14514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14526,11 +14526,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14584,28 +14584,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14614,7 +14614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14624,7 +14624,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14635,7 +14635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14646,7 +14646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14657,47 +14657,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14707,7 +14707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14715,14 +14715,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14730,11 +14730,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14742,11 +14742,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14754,11 +14754,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14766,7 +14766,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14922,19 +14922,19 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(a: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14942,19 +14942,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14962,7 +14962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14972,53 +14972,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15026,7 +15026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -15035,7 +15035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15045,7 +15045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15055,7 +15055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15065,7 +15065,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15075,7 +15075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -15086,7 +15086,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -15096,7 +15096,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15106,7 +15106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -15116,7 +15116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15126,7 +15126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15135,7 +15135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -15143,7 +15143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -15154,7 +15154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -15163,7 +15163,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -15172,7 +15172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -15180,11 +15180,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -15194,15 +15194,15 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 #[repr(C)]
@@ -15256,92 +15256,92 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15349,7 +15349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15358,15 +15358,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15374,11 +15374,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15386,22 +15386,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15411,7 +15411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15419,7 +15419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15541,11 +15541,11 @@ impl Default for ecdsa_method_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15553,11 +15553,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15565,11 +15565,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15577,14 +15577,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15601,7 +15601,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15610,7 +15610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15621,7 +15621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15632,7 +15632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15686,23 +15686,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15710,7 +15710,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15718,7 +15718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15726,7 +15726,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15735,19 +15735,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15755,11 +15755,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15769,7 +15769,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15777,83 +15777,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15991,11 +15991,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -16004,11 +16004,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16019,11 +16019,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16038,7 +16038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16053,7 +16053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16071,7 +16071,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -16086,66 +16086,66 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -16156,7 +16156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -16164,7 +16164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -16173,7 +16173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -16181,102 +16181,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16284,40 +16284,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16326,7 +16326,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16335,7 +16335,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16343,7 +16343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16351,7 +16351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16361,7 +16361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16369,7 +16369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16377,7 +16377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16387,7 +16387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16397,7 +16397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16405,7 +16405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16413,7 +16413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16423,7 +16423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16431,11 +16431,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16443,7 +16443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16452,7 +16452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16460,11 +16460,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16472,7 +16472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16481,7 +16481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16490,7 +16490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16499,7 +16499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16508,7 +16508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16521,7 +16521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16533,7 +16533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16548,31 +16548,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16582,11 +16582,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16596,11 +16596,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16610,11 +16610,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16624,11 +16624,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16638,18 +16638,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16657,18 +16657,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16678,7 +16678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16688,102 +16688,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16791,28 +16791,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16820,7 +16820,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16828,7 +16828,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16838,31 +16838,31 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16876,7 +16876,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16890,15 +16890,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16907,7 +16907,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16915,7 +16915,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16924,22 +16924,22 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16947,40 +16947,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16988,11 +16988,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -17000,11 +17000,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -17012,11 +17012,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -17024,14 +17024,14 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
@@ -17205,7 +17205,7 @@ impl Default for evp_pkey_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17219,7 +17219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17231,7 +17231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17243,11 +17243,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17255,15 +17255,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17350,7 +17350,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17362,27 +17362,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17392,7 +17392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17400,7 +17400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17408,23 +17408,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17433,7 +17433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17609,82 +17609,82 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17693,18 +17693,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17713,7 +17713,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17722,23 +17722,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17754,7 +17754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17772,7 +17772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17785,7 +17785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17798,7 +17798,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17811,7 +17811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17821,19 +17821,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -18092,7 +18092,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -18100,7 +18100,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -18109,7 +18109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -18118,22 +18118,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18141,15 +18141,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18236,66 +18236,66 @@ impl Default for md4_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -18304,7 +18304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -18312,7 +18312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -18320,7 +18320,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -18401,7 +18401,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 #[repr(C)]
@@ -18420,7 +18420,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18428,47 +18428,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18762,51 +18762,51 @@ impl Default for PKCS7 {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7"]
     pub fn d2i_PKCS7(out: *mut *mut PKCS7, inp: *mut *const u8, len: usize) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7"]
     pub fn i2d_PKCS7(p7: *const PKCS7, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_free"]
     pub fn PKCS7_free(p7: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18832,15 +18832,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18848,18 +18848,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18867,79 +18867,79 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18948,11 +18948,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18961,7 +18961,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18970,12 +18970,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18984,7 +18984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18993,7 +18993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19001,7 +19001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19013,7 +19013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19025,7 +19025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19035,7 +19035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19045,7 +19045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19056,7 +19056,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19070,7 +19070,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19082,7 +19082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19093,7 +19093,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19106,7 +19106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19118,7 +19118,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19128,7 +19128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19138,31 +19138,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19173,7 +19173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19184,7 +19184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19197,7 +19197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19208,19 +19208,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19228,19 +19228,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19248,7 +19248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19258,7 +19258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19266,26 +19266,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19294,7 +19294,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19302,11 +19302,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19314,11 +19314,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19328,7 +19328,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19338,7 +19338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19349,7 +19349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19357,7 +19357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 #[repr(C)]
@@ -19858,27 +19858,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19886,51 +19886,51 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *mut X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19943,15 +19943,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19959,7 +19959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19967,7 +19967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19975,15 +19975,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19991,68 +19991,68 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -20060,7 +20060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -20068,25 +20068,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -20094,14 +20094,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -20109,7 +20109,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const ::std::os::raw::c_uchar,
@@ -20117,7 +20117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const ::std::os::raw::c_uchar,
@@ -20125,14 +20125,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_alias_get0"]
     pub fn X509_alias_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_keyid_get0"]
     pub fn X509_keyid_get0(
         x509: *mut X509,
         out_len: *mut ::std::os::raw::c_int,
@@ -20154,23 +20154,23 @@ pub type sk_X509_CRL_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20178,23 +20178,23 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 #[repr(C)]
@@ -20203,19 +20203,19 @@ pub struct stack_st_X509_REVOKED {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20223,7 +20223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20231,7 +20231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20239,11 +20239,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20251,55 +20251,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20307,7 +20307,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20315,25 +20315,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20341,19 +20341,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20361,23 +20361,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *mut X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20385,33 +20385,33 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20419,22 +20419,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20484,19 +20484,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20504,15 +20504,15 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20520,15 +20520,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20536,7 +20536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20544,21 +20544,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20567,7 +20567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20579,7 +20579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20591,7 +20591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20603,19 +20603,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20623,33 +20623,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20658,11 +20658,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20672,7 +20672,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20682,7 +20682,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20692,19 +20692,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20712,18 +20712,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         alg: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20732,7 +20732,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20741,33 +20741,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20791,11 +20791,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20803,18 +20803,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20822,7 +20822,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20830,7 +20830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20838,21 +20838,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -20881,23 +20881,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -20905,11 +20905,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -20918,7 +20918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -20927,15 +20927,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -20943,7 +20943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -20951,7 +20951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20960,7 +20960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -20969,7 +20969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -20978,7 +20978,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -20987,7 +20987,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -20996,259 +20996,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -21256,11 +21256,11 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21270,7 +21270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -21278,14 +21278,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -21295,7 +21295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -21303,42 +21303,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -21347,7 +21347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -21920,11 +21920,11 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -21932,7 +21932,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -21940,54 +21940,54 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ::std::os::raw::c_int,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *mut NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21995,27 +21995,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(xa: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22023,7 +22023,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22032,44 +22032,44 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(a: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         a: *mut *mut X509_PUBKEY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22077,34 +22077,34 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(
         a: *const X509_PUBKEY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *mut X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_free"]
     pub fn X509_SIG_free(a: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         a: *mut *mut X509_SIG,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22112,26 +22112,26 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(
         a: *const X509_SIG,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(a: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         a: *mut *mut X509_ATTRIBUTE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22139,18 +22139,18 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         a: *const X509_ATTRIBUTE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -22158,38 +22158,38 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(x: *mut X509, obj: *mut ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_trust_clear"]
     pub fn X509_trust_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_reject_clear"]
     pub fn X509_reject_clear(x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(a: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         a: *mut *mut X509_REVOKED,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22197,25 +22197,25 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(
         a: *const X509_REVOKED,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22223,7 +22223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         ret: *mut *mut X509_REVOKED,
@@ -22231,23 +22231,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_new"]
     pub fn X509_PKEY_new() -> *mut X509_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PKEY_free"]
     pub fn X509_PKEY_free(a: *mut X509_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(a: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         a: *mut *mut NETSCAPE_SPKI,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22255,26 +22255,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         a: *const NETSCAPE_SPKI,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(a: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         a: *mut *mut NETSCAPE_SPKAC,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22282,26 +22282,26 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         a: *const NETSCAPE_SPKAC,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_new"]
     pub fn X509_INFO_new() -> *mut X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_INFO_free"]
     pub fn X509_INFO_free(a: *mut X509_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         a: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22309,7 +22309,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22319,7 +22319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22329,7 +22329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22339,7 +22339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22351,7 +22351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22362,15 +22362,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *mut X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -22378,18 +22378,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22397,7 +22397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22405,28 +22405,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *mut X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -22436,7 +22436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -22446,7 +22446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -22456,37 +22456,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_diff"]
     pub fn X509_CRL_diff(
         base: *mut X509_CRL,
         newer: *mut X509_CRL,
@@ -22496,66 +22496,66 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         x509: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_private_key"]
     pub fn X509_check_private_key(x509: *mut X509, pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(a: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x: *mut X509) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash"]
     pub fn X509_NAME_hash(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(x: *mut X509_NAME) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         bp: *mut FILE,
         x: *mut X509,
@@ -22564,19 +22564,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_fp"]
     pub fn X509_print_fp(bp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(bp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(bp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22585,7 +22585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22593,7 +22593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22602,7 +22602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22611,15 +22611,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22628,11 +22628,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -22641,7 +22641,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -22651,7 +22651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22660,7 +22660,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -22670,11 +22670,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22682,7 +22682,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -22690,7 +22690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -22698,21 +22698,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -22720,7 +22720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22729,7 +22729,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -22739,11 +22739,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_count"]
     pub fn X509at_get_attr_count(x: *const stack_st_X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_NID"]
     pub fn X509at_get_attr_by_NID(
         x: *const stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22751,7 +22751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr_by_OBJ"]
     pub fn X509at_get_attr_by_OBJ(
         sk: *const stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22759,28 +22759,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_get_attr"]
     pub fn X509at_get_attr(
         x: *const stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_delete_attr"]
     pub fn X509at_delete_attr(
         x: *mut stack_st_X509_ATTRIBUTE,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr"]
     pub fn X509at_add1_attr(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attr: *mut X509_ATTRIBUTE,
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_OBJ"]
     pub fn X509at_add1_attr_by_OBJ(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22790,7 +22790,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_NID"]
     pub fn X509at_add1_attr_by_NID(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22800,7 +22800,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509at_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509at_add1_attr_by_txt"]
     pub fn X509at_add1_attr_by_txt(
         x: *mut *mut stack_st_X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22810,7 +22810,7 @@ extern "C" {
     ) -> *mut stack_st_X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -22820,7 +22820,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -22830,7 +22830,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -22840,14 +22840,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -22856,7 +22856,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -22865,34 +22865,34 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(a: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         a: *mut *mut PKCS8_PRIV_KEY_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -22900,26 +22900,26 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         a: *const PKCS8_PRIV_KEY_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -22930,7 +22930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -22940,11 +22940,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_trust"]
     pub fn X509_check_trust(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22952,19 +22952,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *mut X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_add"]
     pub fn X509_TRUST_add(
         id: ::std::os::raw::c_int,
         flags: ::std::os::raw::c_int,
@@ -22981,19 +22981,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_cleanup"]
     pub fn X509_TRUST_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23080,15 +23080,15 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(a: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         a: *mut *mut RSA_PSS_PARAMS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -23096,14 +23096,14 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         a: *const RSA_PSS_PARAMS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -23222,18 +23222,18 @@ pub type X509_STORE_CTX_lookup_crls_fn = ::std::option::Option<
 pub type X509_STORE_CTX_cleanup_fn =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_idx_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_idx_by_subject"]
     pub fn X509_OBJECT_idx_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23241,7 +23241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_by_subject"]
     pub fn X509_OBJECT_retrieve_by_subject(
         h: *mut stack_st_X509_OBJECT,
         type_: ::std::os::raw::c_int,
@@ -23249,202 +23249,202 @@ extern "C" {
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_retrieve_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_retrieve_match"]
     pub fn X509_OBJECT_retrieve_match(
         h: *mut stack_st_X509_OBJECT,
         x: *mut X509_OBJECT,
     ) -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_up_ref_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_up_ref_count"]
     pub fn X509_OBJECT_up_ref_count(a: *mut X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_free_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_free_contents"]
     pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(a: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(a: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_free"]
     pub fn X509_STORE_free(v: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_certs"]
     pub fn X509_STORE_get1_certs(st: *mut X509_STORE_CTX, nm: *mut X509_NAME)
         -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get1_crls"]
     pub fn X509_STORE_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         ctx: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         ctx: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         ctx: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         ctx: *mut X509_STORE,
         pm: *mut X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(ctx: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify"]
     pub fn X509_STORE_set_verify(ctx: *mut X509_STORE, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
     pub fn X509_STORE_CTX_set_verify(ctx: *mut X509_STORE_CTX, verify: X509_STORE_CTX_verify_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify"]
     pub fn X509_STORE_get_verify(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(ctx: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_verify_cb"]
     pub fn X509_STORE_get_verify_cb(ctx: *mut X509_STORE) -> X509_STORE_CTX_verify_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_issuer"]
     pub fn X509_STORE_set_get_issuer(
         ctx: *mut X509_STORE,
         get_issuer: X509_STORE_CTX_get_issuer_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_issuer"]
     pub fn X509_STORE_get_get_issuer(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_issuer_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_issued"]
     pub fn X509_STORE_set_check_issued(
         ctx: *mut X509_STORE,
         check_issued: X509_STORE_CTX_check_issued_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_issued"]
     pub fn X509_STORE_get_check_issued(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_issued_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_revocation"]
     pub fn X509_STORE_set_check_revocation(
         ctx: *mut X509_STORE,
         check_revocation: X509_STORE_CTX_check_revocation_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_revocation"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_revocation"]
     pub fn X509_STORE_get_check_revocation(
         ctx: *mut X509_STORE,
     ) -> X509_STORE_CTX_check_revocation_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(ctx: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_get_crl"]
     pub fn X509_STORE_get_get_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_get_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(ctx: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_check_crl"]
     pub fn X509_STORE_get_check_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_check_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cert_crl"]
     pub fn X509_STORE_set_cert_crl(ctx: *mut X509_STORE, cert_crl: X509_STORE_CTX_cert_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cert_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cert_crl"]
     pub fn X509_STORE_get_cert_crl(ctx: *mut X509_STORE) -> X509_STORE_CTX_cert_crl_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_certs"]
     pub fn X509_STORE_set_lookup_certs(
         ctx: *mut X509_STORE,
         lookup_certs: X509_STORE_CTX_lookup_certs_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_certs"]
     pub fn X509_STORE_get_lookup_certs(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_certs_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_lookup_crls"]
     pub fn X509_STORE_set_lookup_crls(
         ctx: *mut X509_STORE,
         lookup_crls: X509_STORE_CTX_lookup_crls_fn,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_lookup_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_lookup_crls"]
     pub fn X509_STORE_get_lookup_crls(ctx: *mut X509_STORE) -> X509_STORE_CTX_lookup_crls_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_cleanup"]
     pub fn X509_STORE_set_cleanup(ctx: *mut X509_STORE, cleanup: X509_STORE_CTX_cleanup_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_cleanup"]
     pub fn X509_STORE_get_cleanup(ctx: *mut X509_STORE) -> X509_STORE_CTX_cleanup_fn;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23452,15 +23452,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_zero"]
     pub fn X509_STORE_CTX_zero(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -23469,50 +23469,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *mut X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *mut X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(ctx: *mut X509_STORE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_get_by_subject"]
     pub fn X509_STORE_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23521,7 +23521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23531,7 +23531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23539,7 +23539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23547,7 +23547,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23555,19 +23555,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_new"]
     pub fn X509_LOOKUP_new(method: *mut X509_LOOKUP_METHOD) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_init"]
     pub fn X509_LOOKUP_init(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_by_subject"]
     pub fn X509_LOOKUP_by_subject(
         ctx: *mut X509_LOOKUP,
         type_: ::std::os::raw::c_int,
@@ -23576,11 +23576,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_LOOKUP_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_LOOKUP_shutdown"]
     pub fn X509_LOOKUP_shutdown(ctx: *mut X509_LOOKUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23588,81 +23588,81 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, s: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(c: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_purpose_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_purpose_inherit"]
     pub fn X509_STORE_CTX_purpose_inherit(
         ctx: *mut X509_STORE_CTX,
         def_purpose: ::std::os::raw::c_int,
@@ -23671,11 +23671,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23683,7 +23683,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -23691,7 +23691,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23703,109 +23703,109 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_name"]
     pub fn X509_VERIFY_PARAM_set1_name(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23813,7 +23813,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -23821,20 +23821,20 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_peername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_peername"]
     pub fn X509_VERIFY_PARAM_get0_peername(
         arg1: *mut X509_VERIFY_PARAM,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -23842,7 +23842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const ::std::os::raw::c_uchar,
@@ -23850,42 +23850,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0_name"]
     pub fn X509_VERIFY_PARAM_get0_name(
         param: *const X509_VERIFY_PARAM,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_add0_table"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_add0_table"]
     pub fn X509_VERIFY_PARAM_add0_table(param: *mut X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get_count"]
     pub fn X509_VERIFY_PARAM_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_get0"]
     pub fn X509_VERIFY_PARAM_get0(id: ::std::os::raw::c_int) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_lookup"]
     pub fn X509_VERIFY_PARAM_lookup(
         name: *const ::std::os::raw::c_char,
     ) -> *const X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_VERIFY_PARAM_table_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_VERIFY_PARAM_table_cleanup"]
     pub fn X509_VERIFY_PARAM_table_cleanup();
 }
 pub type pem_password_cb = ::std::option::Option<
@@ -23897,14 +23897,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -23914,7 +23914,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23924,7 +23924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -23934,7 +23934,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -23946,7 +23946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23957,7 +23957,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -23971,7 +23971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -23980,7 +23980,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -23990,7 +23990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -24000,7 +24000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24011,7 +24011,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -24025,7 +24025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -24034,7 +24034,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -24043,11 +24043,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_proc_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_proc_type"]
     pub fn PEM_proc_type(buf: *mut ::std::os::raw::c_char, type_: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_dek_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_dek_info"]
     pub fn PEM_dek_info(
         buf: *mut ::std::os::raw::c_char,
         type_: *const ::std::os::raw::c_char,
@@ -24056,7 +24056,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24065,7 +24065,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24074,15 +24074,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -24091,7 +24091,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -24100,15 +24100,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -24117,7 +24117,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -24126,23 +24126,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -24151,7 +24151,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -24160,15 +24160,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -24177,7 +24177,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -24186,15 +24186,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -24203,7 +24203,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -24212,15 +24212,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24229,7 +24229,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -24238,21 +24238,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24261,7 +24261,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24270,7 +24270,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -24282,7 +24282,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -24294,7 +24294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24303,7 +24303,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24312,15 +24312,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -24329,7 +24329,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -24338,15 +24338,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24355,7 +24355,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24364,7 +24364,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -24376,7 +24376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -24388,7 +24388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24397,7 +24397,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24406,15 +24406,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -24423,7 +24423,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -24432,15 +24432,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24449,7 +24449,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24458,7 +24458,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -24470,7 +24470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -24482,7 +24482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -24491,7 +24491,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -24500,15 +24500,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -24517,7 +24517,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -24526,15 +24526,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24543,7 +24543,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24552,7 +24552,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24564,7 +24564,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24576,7 +24576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24585,7 +24585,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24594,15 +24594,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24614,7 +24614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *mut EVP_PKEY,
@@ -24626,7 +24626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24638,7 +24638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -24650,7 +24650,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -24659,7 +24659,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24671,7 +24671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24683,7 +24683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24695,7 +24695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -24704,7 +24704,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -24716,7 +24716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -24729,7 +24729,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -24743,7 +24743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -24751,7 +24751,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -24759,7 +24759,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -24768,11 +24768,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -24780,27 +24780,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24810,7 +24810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -24818,7 +24818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -24833,74 +24833,74 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25001,19 +25001,19 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25078,11 +25078,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -25169,11 +25169,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -25181,42 +25181,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -25291,15 +25291,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25312,7 +25312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -25327,18 +25327,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25347,14 +25347,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25363,7 +25363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25374,7 +25374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -25383,7 +25383,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -25395,7 +25395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -25407,18 +25407,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25426,14 +25426,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -25441,7 +25441,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25455,7 +25455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -25470,7 +25470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_raw"]
     pub fn TRUST_TOKEN_ISSUER_redeem_raw(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25483,7 +25483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -25498,7 +25498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -27206,15 +27206,15 @@ impl Default for PROXY_CERT_INFO_EXTENSION_st {
 }
 pub type PROXY_CERT_INFO_EXTENSION = PROXY_CERT_INFO_EXTENSION_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_new"]
     pub fn PROXY_POLICY_new() -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_free"]
     pub fn PROXY_POLICY_free(a: *mut PROXY_POLICY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_POLICY"]
     pub fn d2i_PROXY_POLICY(
         a: *mut *mut PROXY_POLICY,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27222,26 +27222,26 @@ extern "C" {
     ) -> *mut PROXY_POLICY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_POLICY"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_POLICY"]
     pub fn i2d_PROXY_POLICY(
         a: *const PROXY_POLICY,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_POLICY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_POLICY_it"]
     pub static PROXY_POLICY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_new"]
     pub fn PROXY_CERT_INFO_EXTENSION_new() -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_free"]
     pub fn PROXY_CERT_INFO_EXTENSION_free(a: *mut PROXY_CERT_INFO_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_PROXY_CERT_INFO_EXTENSION"]
     pub fn d2i_PROXY_CERT_INFO_EXTENSION(
         a: *mut *mut PROXY_CERT_INFO_EXTENSION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27249,14 +27249,14 @@ extern "C" {
     ) -> *mut PROXY_CERT_INFO_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_PROXY_CERT_INFO_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_PROXY_CERT_INFO_EXTENSION"]
     pub fn i2d_PROXY_CERT_INFO_EXTENSION(
         a: *const PROXY_CERT_INFO_EXTENSION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PROXY_CERT_INFO_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PROXY_CERT_INFO_EXTENSION_it"]
     pub static PROXY_CERT_INFO_EXTENSION_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -27488,15 +27488,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27504,26 +27504,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27531,26 +27531,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(a: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         a: *mut *mut GENERAL_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27558,29 +27558,29 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(
         a: *mut GENERAL_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_it"]
     pub static GENERAL_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(a: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_cmp"]
     pub fn GENERAL_NAME_cmp(
         a: *const GENERAL_NAME,
         b: *const GENERAL_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAME,
@@ -27588,19 +27588,19 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *mut GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(a: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         a: *mut *mut GENERAL_NAMES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27608,18 +27608,18 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(
         a: *mut GENERAL_NAMES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAMES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAMES_it"]
     pub static GENERAL_NAMES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *mut GENERAL_NAMES,
@@ -27627,7 +27627,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAMES"]
     pub fn v2i_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27635,15 +27635,15 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_free"]
     pub fn OTHERNAME_free(a: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_OTHERNAME"]
     pub fn d2i_OTHERNAME(
         a: *mut *mut OTHERNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27651,26 +27651,26 @@ extern "C" {
     ) -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_OTHERNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_OTHERNAME"]
     pub fn i2d_OTHERNAME(
         a: *const OTHERNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_it"]
     pub static OTHERNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(a: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EDIPARTYNAME"]
     pub fn d2i_EDIPARTYNAME(
         a: *mut *mut EDIPARTYNAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27678,22 +27678,22 @@ extern "C" {
     ) -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EDIPARTYNAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EDIPARTYNAME"]
     pub fn i2d_EDIPARTYNAME(
         a: *const EDIPARTYNAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EDIPARTYNAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EDIPARTYNAME_it"]
     pub static EDIPARTYNAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OTHERNAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OTHERNAME_cmp"]
     pub fn OTHERNAME_cmp(a: *mut OTHERNAME, b: *mut OTHERNAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         a: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -27701,14 +27701,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         a: *const GENERAL_NAME,
         ptype: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -27716,7 +27716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         poid: *mut *mut ASN1_OBJECT,
@@ -27724,14 +27724,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ia5: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -27739,15 +27739,15 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27755,33 +27755,33 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2a_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2a_ACCESS_DESCRIPTION"]
     pub fn i2a_ACCESS_DESCRIPTION(
         bp: *mut BIO,
         a: *const ACCESS_DESCRIPTION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27789,26 +27789,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27816,26 +27816,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27843,26 +27843,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27870,26 +27870,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27897,26 +27897,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27924,26 +27924,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27951,26 +27951,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -27978,26 +27978,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28005,38 +28005,38 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(x: *mut X509, nc: *mut NAME_CONSTRAINTS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28044,26 +28044,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -28071,70 +28071,70 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_GENERAL_NAME"]
     pub fn a2i_GENERAL_NAME(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28145,7 +28145,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME"]
     pub fn v2i_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -28153,7 +28153,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_v2i_GENERAL_NAME_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_v2i_GENERAL_NAME_ex"]
     pub fn v2i_GENERAL_NAME_ex(
         out: *mut GENERAL_NAME,
         method: *const X509V3_EXT_METHOD,
@@ -28163,7 +28163,7 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 #[repr(C)]
@@ -28261,7 +28261,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -28272,11 +28272,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28285,7 +28285,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28294,7 +28294,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -28303,7 +28303,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28312,7 +28312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28321,7 +28321,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28330,7 +28330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -28339,67 +28339,67 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         meth: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         meth: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_list"]
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_cleanup"]
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28408,14 +28408,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -28423,7 +28423,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -28433,7 +28433,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_val_prn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_val_prn"]
     pub fn X509V3_EXT_val_prn(
         out: *mut BIO,
         val: *const stack_st_CONF_VALUE,
@@ -28442,7 +28442,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -28451,7 +28451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -28460,7 +28460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -28470,11 +28470,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ca"]
     pub fn X509_check_ca(x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_purpose"]
     pub fn X509_check_purpose(
         x: *mut X509,
         id: ::std::os::raw::c_int,
@@ -28482,70 +28482,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_akid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_akid"]
     pub fn X509_check_akid(issuer: *mut X509, akid: *mut AUTHORITY_KEYID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_key_usage"]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *mut X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_add"]
     pub fn X509_PURPOSE_add(
         id: ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
@@ -28563,43 +28563,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_cleanup"]
     pub fn X509_PURPOSE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_email"]
     pub fn X509_get1_email(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(x: *mut X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_host"]
     pub fn X509_check_host(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28609,7 +28609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_email"]
     pub fn X509_check_email(
         x: *mut X509,
         chk: *const ::std::os::raw::c_char,
@@ -28618,7 +28618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip"]
     pub fn X509_check_ip(
         x: *mut X509,
         chk: *const ::std::os::raw::c_uchar,
@@ -28627,7 +28627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x: *mut X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -28635,11 +28635,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -28705,119 +28705,119 @@ impl static_assertion_at_line_255_error_is_max_overheads_are_inconsistent {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_method"]
     pub fn TLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_method"]
     pub fn DTLS_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_with_buffers_method"]
     pub fn TLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_with_buffers_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_with_buffers_method"]
     pub fn DTLS_with_buffers_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_new"]
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_up_ref"]
     pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_free"]
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_new"]
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_free"]
     pub fn SSL_free(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_SSL_CTX"]
     pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_connect_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_connect_state"]
     pub fn SSL_set_connect_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_accept_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_accept_state"]
     pub fn SSL_set_accept_state(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_server"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_server"]
     pub fn SSL_is_server(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_dtls"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_dtls"]
     pub fn SSL_is_dtls(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_bio"]
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_rbio"]
     pub fn SSL_set0_rbio(ssl: *mut SSL, rbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_wbio"]
     pub fn SSL_set0_wbio(ssl: *mut SSL, wbio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_rbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_rbio"]
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_wbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_wbio"]
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_fd"]
     pub fn SSL_get_fd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_rfd"]
     pub fn SSL_get_rfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_wfd"]
     pub fn SSL_get_wfd(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_fd"]
     pub fn SSL_set_fd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_rfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_rfd"]
     pub fn SSL_set_rfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_wfd"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_wfd"]
     pub fn SSL_set_wfd(ssl: *mut SSL, fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_do_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_do_handshake"]
     pub fn SSL_do_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_connect"]
     pub fn SSL_connect(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_accept"]
     pub fn SSL_accept(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_read"]
     pub fn SSL_read(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -28825,7 +28825,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_peek"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_peek"]
     pub fn SSL_peek(
         ssl: *mut SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -28833,15 +28833,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_pending"]
     pub fn SSL_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_has_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_has_pending"]
     pub fn SSL_has_pending(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_write"]
     pub fn SSL_write(
         ssl: *mut SSL,
         buf: *const ::std::os::raw::c_void,
@@ -28849,220 +28849,220 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_key_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_key_update"]
     pub fn SSL_key_update(
         ssl: *mut SSL,
         request_type: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_shutdown"]
     pub fn SSL_shutdown(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_quiet_shutdown"]
     pub fn SSL_CTX_set_quiet_shutdown(ctx: *mut SSL_CTX, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_quiet_shutdown"]
     pub fn SSL_CTX_get_quiet_shutdown(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quiet_shutdown"]
     pub fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_quiet_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_quiet_shutdown"]
     pub fn SSL_get_quiet_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_error"]
     pub fn SSL_get_error(ssl: *const SSL, ret_code: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_error_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_error_description"]
     pub fn SSL_error_description(err: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_mtu"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_mtu"]
     pub fn SSL_set_mtu(ssl: *mut SSL, mtu: ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_set_initial_timeout_duration"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_set_initial_timeout_duration"]
     pub fn DTLSv1_set_initial_timeout_duration(ssl: *mut SSL, duration_ms: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_get_timeout"]
     pub fn DTLSv1_get_timeout(ssl: *const SSL, out: *mut timeval) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_handle_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_handle_timeout"]
     pub fn DTLSv1_handle_timeout(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_min_proto_version"]
     pub fn SSL_CTX_set_min_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_proto_version"]
     pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_min_proto_version"]
     pub fn SSL_CTX_get_min_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_max_proto_version"]
     pub fn SSL_CTX_get_max_proto_version(ctx: *const SSL_CTX) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_min_proto_version"]
     pub fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_proto_version"]
     pub fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_min_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_min_proto_version"]
     pub fn SSL_get_min_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_max_proto_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_max_proto_version"]
     pub fn SSL_get_max_proto_version(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_version"]
     pub fn SSL_version(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_options"]
     pub fn SSL_CTX_set_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_options"]
     pub fn SSL_CTX_clear_options(ctx: *mut SSL_CTX, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_options"]
     pub fn SSL_CTX_get_options(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_options"]
     pub fn SSL_set_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_options"]
     pub fn SSL_clear_options(ssl: *mut SSL, options: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_options"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_options"]
     pub fn SSL_get_options(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_mode"]
     pub fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_mode"]
     pub fn SSL_CTX_clear_mode(ctx: *mut SSL_CTX, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_mode"]
     pub fn SSL_CTX_get_mode(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_mode"]
     pub fn SSL_set_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_mode"]
     pub fn SSL_clear_mode(ssl: *mut SSL, mode: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_mode"]
     pub fn SSL_get_mode(ssl: *const SSL) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_buffer_pool"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_buffer_pool"]
     pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate"]
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate"]
     pub fn SSL_use_certificate(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey"]
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey"]
     pub fn SSL_use_PrivateKey(ssl: *mut SSL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_chain"]
     pub fn SSL_CTX_set0_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_chain"]
     pub fn SSL_CTX_set1_chain(
         ctx: *mut SSL_CTX,
         chain: *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_chain"]
     pub fn SSL_set0_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_chain"]
     pub fn SSL_set1_chain(ssl: *mut SSL, chain: *mut stack_st_X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add0_chain_cert"]
     pub fn SSL_CTX_add0_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add1_chain_cert"]
     pub fn SSL_CTX_add1_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add0_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add0_chain_cert"]
     pub fn SSL_add0_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_extra_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_extra_chain_cert"]
     pub fn SSL_CTX_add_extra_chain_cert(
         ctx: *mut SSL_CTX,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add1_chain_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add1_chain_cert"]
     pub fn SSL_add1_chain_cert(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_chain_certs"]
     pub fn SSL_CTX_clear_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_clear_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_clear_extra_chain_certs"]
     pub fn SSL_CTX_clear_extra_chain_certs(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear_chain_certs"]
     pub fn SSL_clear_chain_certs(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_cb"]
     pub fn SSL_CTX_set_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -29075,7 +29075,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_cert_cb"]
     pub fn SSL_set_cert_cb(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -29088,71 +29088,71 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_certificate_types"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_certificate_types"]
     pub fn SSL_get0_certificate_types(ssl: *const SSL, out_types: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_verify_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_verify_algorithms"]
     pub fn SSL_get0_peer_verify_algorithms(ssl: *const SSL, out_sigalgs: *mut *const u16) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_delegation_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_delegation_algorithms"]
     pub fn SSL_get0_peer_delegation_algorithms(
         ssl: *const SSL,
         out_sigalgs: *mut *const u16,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_certs_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_certs_clear"]
     pub fn SSL_certs_clear(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_check_private_key"]
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_check_private_key"]
     pub fn SSL_check_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_certificate"]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_certificate"]
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_privatekey"]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_privatekey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_privatekey"]
     pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_chain_certs"]
     pub fn SSL_CTX_get0_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_extra_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_extra_chain_certs"]
     pub fn SSL_CTX_get_extra_chain_certs(
         ctx: *const SSL_CTX,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_chain_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_chain_certs"]
     pub fn SSL_get0_chain_certs(
         ssl: *const SSL,
         out_chain: *mut *mut stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_signed_cert_timestamp_list"]
     pub fn SSL_CTX_set_signed_cert_timestamp_list(
         ctx: *mut SSL_CTX,
         list: *const u8,
@@ -29160,7 +29160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_signed_cert_timestamp_list"]
     pub fn SSL_set_signed_cert_timestamp_list(
         ctx: *mut SSL,
         list: *const u8,
@@ -29168,7 +29168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ocsp_response"]
     pub fn SSL_CTX_set_ocsp_response(
         ctx: *mut SSL_CTX,
         response: *const u8,
@@ -29176,7 +29176,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ocsp_response"]
     pub fn SSL_set_ocsp_response(
         ssl: *mut SSL,
         response: *const u8,
@@ -29184,26 +29184,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_name"]
     pub fn SSL_get_signature_algorithm_name(
         sigalg: u16,
         include_curve: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_key_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_key_type"]
     pub fn SSL_get_signature_algorithm_key_type(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_signature_algorithm_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_signature_algorithm_digest"]
     pub fn SSL_get_signature_algorithm_digest(sigalg: u16) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_signature_algorithm_rsa_pss"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_signature_algorithm_rsa_pss"]
     pub fn SSL_is_signature_algorithm_rsa_pss(sigalg: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_signing_algorithm_prefs"]
     pub fn SSL_CTX_set_signing_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -29211,7 +29211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_signing_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_signing_algorithm_prefs"]
     pub fn SSL_set_signing_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -29219,7 +29219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_chain_and_key"]
     pub fn SSL_CTX_set_chain_and_key(
         ctx: *mut SSL_CTX,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29229,7 +29229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_chain_and_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_chain_and_key"]
     pub fn SSL_set_chain_and_key(
         ssl: *mut SSL,
         certs: *const *mut CRYPTO_BUFFER,
@@ -29239,19 +29239,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_chain"]
     pub fn SSL_CTX_get0_chain(ctx: *const SSL_CTX) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey"]
     pub fn SSL_CTX_use_RSAPrivateKey(ctx: *mut SSL_CTX, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey"]
     pub fn SSL_use_RSAPrivateKey(ssl: *mut SSL, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_ASN1"]
     pub fn SSL_CTX_use_certificate_ASN1(
         ctx: *mut SSL_CTX,
         der_len: usize,
@@ -29259,7 +29259,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate_ASN1"]
     pub fn SSL_use_certificate_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29267,7 +29267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_ASN1"]
     pub fn SSL_CTX_use_PrivateKey_ASN1(
         pk: ::std::os::raw::c_int,
         ctx: *mut SSL_CTX,
@@ -29276,7 +29276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey_ASN1"]
     pub fn SSL_use_PrivateKey_ASN1(
         type_: ::std::os::raw::c_int,
         ssl: *mut SSL,
@@ -29285,7 +29285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_ASN1"]
     pub fn SSL_CTX_use_RSAPrivateKey_ASN1(
         ctx: *mut SSL_CTX,
         der: *const u8,
@@ -29293,7 +29293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_ASN1"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_ASN1"]
     pub fn SSL_use_RSAPrivateKey_ASN1(
         ssl: *mut SSL,
         der: *const u8,
@@ -29301,7 +29301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_RSAPrivateKey_file"]
     pub fn SSL_CTX_use_RSAPrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29309,7 +29309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_RSAPrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_RSAPrivateKey_file"]
     pub fn SSL_use_RSAPrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29317,7 +29317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_file"]
     pub fn SSL_CTX_use_certificate_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29325,7 +29325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_certificate_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_certificate_file"]
     pub fn SSL_use_certificate_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29333,7 +29333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_PrivateKey_file"]
     pub fn SSL_CTX_use_PrivateKey_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
@@ -29341,7 +29341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_PrivateKey_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_PrivateKey_file"]
     pub fn SSL_use_PrivateKey_file(
         ssl: *mut SSL,
         file: *const ::std::os::raw::c_char,
@@ -29349,29 +29349,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_certificate_chain_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_certificate_chain_file"]
     pub fn SSL_CTX_use_certificate_chain_file(
         ctx: *mut SSL_CTX,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb"]
     pub fn SSL_CTX_set_default_passwd_cb(ctx: *mut SSL_CTX, cb: pem_password_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb"]
     pub fn SSL_CTX_get_default_passwd_cb(ctx: *const SSL_CTX) -> pem_password_cb;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_passwd_cb_userdata"]
     pub fn SSL_CTX_set_default_passwd_cb_userdata(
         ctx: *mut SSL_CTX,
         data: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_default_passwd_cb_userdata"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_default_passwd_cb_userdata"]
     pub fn SSL_CTX_get_default_passwd_cb_userdata(
         ctx: *const SSL_CTX,
     ) -> *mut ::std::os::raw::c_void;
@@ -29460,18 +29460,18 @@ fn bindgen_test_layout_ssl_private_key_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_private_key_method"]
     pub fn SSL_set_private_key_method(ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_private_key_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_private_key_method"]
     pub fn SSL_CTX_set_private_key_method(
         ctx: *mut SSL_CTX,
         key_method: *const SSL_PRIVATE_KEY_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_can_release_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_can_release_private_key"]
     pub fn SSL_can_release_private_key(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -29496,156 +29496,156 @@ pub type sk_SSL_CIPHER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_cipher_by_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_cipher_by_value"]
     pub fn SSL_get_cipher_by_value(value: u16) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_id"]
     pub fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_protocol_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_protocol_id"]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_is_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_is_aead"]
     pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_is_block_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_is_block_cipher"]
     pub fn SSL_CIPHER_is_block_cipher(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_cipher_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_cipher_nid"]
     pub fn SSL_CIPHER_get_cipher_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_digest_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_digest_nid"]
     pub fn SSL_CIPHER_get_digest_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_nid"]
     pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_auth_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_auth_nid"]
     pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_prf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_prf_nid"]
     pub fn SSL_CIPHER_get_prf_nid(cipher: *const SSL_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_min_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_min_version"]
     pub fn SSL_CIPHER_get_min_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_max_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_max_version"]
     pub fn SSL_CIPHER_get_max_version(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_standard_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_standard_name"]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_name"]
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_kx_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_kx_name"]
     pub fn SSL_CIPHER_get_kx_name(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_bits"]
     pub fn SSL_CIPHER_get_bits(
         cipher: *const SSL_CIPHER,
         out_alg_bits: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_strict_cipher_list"]
     pub fn SSL_CTX_set_strict_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cipher_list"]
     pub fn SSL_CTX_set_cipher_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_strict_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_strict_cipher_list"]
     pub fn SSL_set_strict_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ciphersuites"]
     pub fn SSL_CTX_set_ciphersuites(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ciphersuites"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ciphersuites"]
     pub fn SSL_set_ciphersuites(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_cipher_list"]
     pub fn SSL_set_cipher_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ciphers"]
     pub fn SSL_CTX_get_ciphers(ctx: *const SSL_CTX) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_cipher_in_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_cipher_in_group"]
     pub fn SSL_CTX_cipher_in_group(ctx: *const SSL_CTX, i: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ciphers"]
     pub fn SSL_get_ciphers(ssl: *const SSL) -> *mut stack_st_SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_is_init_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_is_init_finished"]
     pub fn SSL_is_init_finished(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_init"]
     pub fn SSL_in_init(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_false_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_false_start"]
     pub fn SSL_in_false_start(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_certificate"]
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_cert_chain"]
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_full_cert_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_full_cert_chain"]
     pub fn SSL_get_peer_full_cert_chain(ssl: *const SSL) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_certificates"]
     pub fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_signed_cert_timestamp_list"]
     pub fn SSL_get0_signed_cert_timestamp_list(
         ssl: *const SSL,
         out: *mut *const u8,
@@ -29653,11 +29653,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ocsp_response"]
     pub fn SSL_get0_ocsp_response(ssl: *const SSL, out: *mut *const u8, out_len: *mut usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tls_unique"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tls_unique"]
     pub fn SSL_get_tls_unique(
         ssl: *const SSL,
         out: *mut u8,
@@ -29666,23 +29666,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_extms_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_extms_support"]
     pub fn SSL_get_extms_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_cipher"]
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_session_reused"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_session_reused"]
     pub fn SSL_session_reused(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_secure_renegotiation_support"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_secure_renegotiation_support"]
     pub fn SSL_get_secure_renegotiation_support(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_export_keying_material"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_export_keying_material"]
     pub fn SSL_export_keying_material(
         ssl: *mut SSL,
         out: *mut u8,
@@ -29695,7 +29695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_bio_SSL_SESSION"]
     pub fn PEM_read_bio_SSL_SESSION(
         bp: *mut BIO,
         x: *mut *mut SSL_SESSION,
@@ -29704,7 +29704,7 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_read_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_read_SSL_SESSION"]
     pub fn PEM_read_SSL_SESSION(
         fp: *mut FILE,
         x: *mut *mut SSL_SESSION,
@@ -29713,27 +29713,27 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_bio_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_bio_SSL_SESSION"]
     pub fn PEM_write_bio_SSL_SESSION(bp: *mut BIO, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_PEM_write_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_PEM_write_SSL_SESSION"]
     pub fn PEM_write_SSL_SESSION(fp: *mut FILE, x: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_new"]
     pub fn SSL_SESSION_new(ctx: *const SSL_CTX) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_up_ref"]
     pub fn SSL_SESSION_up_ref(session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_free"]
     pub fn SSL_SESSION_free(session: *mut SSL_SESSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_to_bytes"]
     pub fn SSL_SESSION_to_bytes(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29741,7 +29741,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_to_bytes_for_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_to_bytes_for_ticket"]
     pub fn SSL_SESSION_to_bytes_for_ticket(
         in_: *const SSL_SESSION,
         out_data: *mut *mut u8,
@@ -29749,7 +29749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_from_bytes"]
     pub fn SSL_SESSION_from_bytes(
         in_: *const u8,
         in_len: usize,
@@ -29757,29 +29757,29 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_version"]
     pub fn SSL_SESSION_get_version(session: *const SSL_SESSION) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_protocol_version"]
     pub fn SSL_SESSION_get_protocol_version(session: *const SSL_SESSION) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_protocol_version"]
     pub fn SSL_SESSION_set_protocol_version(
         session: *mut SSL_SESSION,
         version: u16,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_id"]
     pub fn SSL_SESSION_get_id(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set1_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set1_id"]
     pub fn SSL_SESSION_set1_id(
         session: *mut SSL_SESSION,
         sid: *const u8,
@@ -29787,25 +29787,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_time"]
     pub fn SSL_SESSION_get_time(session: *const SSL_SESSION) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_timeout"]
     pub fn SSL_SESSION_get_timeout(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer"]
     pub fn SSL_SESSION_get0_peer(session: *const SSL_SESSION) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_certificates"]
     pub fn SSL_SESSION_get0_peer_certificates(
         session: *const SSL_SESSION,
     ) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_signed_cert_timestamp_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_signed_cert_timestamp_list"]
     pub fn SSL_SESSION_get0_signed_cert_timestamp_list(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -29813,7 +29813,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_ocsp_response"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_ocsp_response"]
     pub fn SSL_SESSION_get0_ocsp_response(
         session: *const SSL_SESSION,
         out: *mut *const u8,
@@ -29821,7 +29821,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_master_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_master_key"]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut u8,
@@ -29829,22 +29829,22 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_time"]
     pub fn SSL_SESSION_set_time(session: *mut SSL_SESSION, time: u64) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_timeout"]
     pub fn SSL_SESSION_set_timeout(session: *mut SSL_SESSION, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_id_context"]
     pub fn SSL_SESSION_get0_id_context(
         session: *const SSL_SESSION,
         out_len: *mut ::std::os::raw::c_uint,
     ) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set1_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set1_id_context"]
     pub fn SSL_SESSION_set1_id_context(
         session: *mut SSL_SESSION,
         sid_ctx: *const u8,
@@ -29852,19 +29852,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_should_be_single_use"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_should_be_single_use"]
     pub fn SSL_SESSION_should_be_single_use(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_is_resumable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_is_resumable"]
     pub fn SSL_SESSION_is_resumable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_has_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_has_ticket"]
     pub fn SSL_SESSION_has_ticket(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_ticket"]
     pub fn SSL_SESSION_get0_ticket(
         session: *const SSL_SESSION,
         out_ticket: *mut *const u8,
@@ -29872,7 +29872,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_ticket"]
     pub fn SSL_SESSION_set_ticket(
         session: *mut SSL_SESSION,
         ticket: *const u8,
@@ -29880,19 +29880,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ticket_lifetime_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ticket_lifetime_hint"]
     pub fn SSL_SESSION_get_ticket_lifetime_hint(session: *const SSL_SESSION) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_cipher"]
     pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_has_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_has_peer_sha256"]
     pub fn SSL_SESSION_has_peer_sha256(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get0_peer_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get0_peer_sha256"]
     pub fn SSL_SESSION_get0_peer_sha256(
         session: *const SSL_SESSION,
         out_ptr: *mut *const u8,
@@ -29900,34 +29900,34 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_cache_mode"]
     pub fn SSL_CTX_set_session_cache_mode(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_session_cache_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_session_cache_mode"]
     pub fn SSL_CTX_get_session_cache_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_session"]
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_timeout"]
     pub fn SSL_CTX_set_timeout(ctx: *mut SSL_CTX, timeout: u32) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_psk_dhe_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_psk_dhe_timeout"]
     pub fn SSL_CTX_set_session_psk_dhe_timeout(ctx: *mut SSL_CTX, timeout: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_timeout"]
     pub fn SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_session_id_context"]
     pub fn SSL_CTX_set_session_id_context(
         ctx: *mut SSL_CTX,
         sid_ctx: *const u8,
@@ -29935,7 +29935,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_session_id_context"]
     pub fn SSL_set_session_id_context(
         ssl: *mut SSL,
         sid_ctx: *const u8,
@@ -29943,44 +29943,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_session_id_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_session_id_context"]
     pub fn SSL_get0_session_id_context(ssl: *const SSL, out_len: *mut usize) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_cache_size"]
     pub fn SSL_CTX_sess_set_cache_size(
         ctx: *mut SSL_CTX,
         size: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_cache_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_cache_size"]
     pub fn SSL_CTX_sess_get_cache_size(ctx: *const SSL_CTX) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_number"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_number"]
     pub fn SSL_CTX_sess_number(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_session"]
     pub fn SSL_CTX_add_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_remove_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_remove_session"]
     pub fn SSL_CTX_remove_session(
         ctx: *mut SSL_CTX,
         session: *mut SSL_SESSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_flush_sessions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_flush_sessions"]
     pub fn SSL_CTX_flush_sessions(ctx: *mut SSL_CTX, time: u64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_new_cb"]
     pub fn SSL_CTX_sess_set_new_cb(
         ctx: *mut SSL_CTX,
         new_session_cb: ::std::option::Option<
@@ -29989,7 +29989,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_new_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_new_cb"]
     pub fn SSL_CTX_sess_get_new_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -29997,7 +29997,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_remove_cb"]
     pub fn SSL_CTX_sess_set_remove_cb(
         ctx: *mut SSL_CTX,
         remove_session_cb: ::std::option::Option<
@@ -30006,13 +30006,13 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_remove_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_remove_cb"]
     pub fn SSL_CTX_sess_get_remove_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, arg1: *mut SSL_SESSION)>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_set_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_set_get_cb"]
     pub fn SSL_CTX_sess_set_get_cb(
         ctx: *mut SSL_CTX,
         get_session_cb: ::std::option::Option<
@@ -30026,7 +30026,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_get_get_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_get_get_cb"]
     pub fn SSL_CTX_sess_get_get_cb(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -30039,11 +30039,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_magic_pending_session_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_magic_pending_session_ptr"]
     pub fn SSL_magic_pending_session_ptr() -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_tlsext_ticket_keys"]
     pub fn SSL_CTX_get_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         out: *mut ::std::os::raw::c_void,
@@ -30051,7 +30051,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_keys"]
     pub fn SSL_CTX_set_tlsext_ticket_keys(
         ctx: *mut SSL_CTX,
         in_: *const ::std::os::raw::c_void,
@@ -30059,7 +30059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_ticket_key_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_ticket_key_cb"]
     pub fn SSL_CTX_set_tlsext_ticket_key_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30151,14 +30151,14 @@ fn bindgen_test_layout_ssl_ticket_aead_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ticket_aead_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ticket_aead_method"]
     pub fn SSL_CTX_set_ticket_aead_method(
         ctx: *mut SSL_CTX,
         aead_method: *const SSL_TICKET_AEAD_METHOD,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_process_tls13_new_session_ticket"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_process_tls13_new_session_ticket"]
     pub fn SSL_process_tls13_new_session_ticket(
         ssl: *mut SSL,
         buf: *const u8,
@@ -30166,15 +30166,15 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_num_tickets"]
     pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_num_tickets"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_num_tickets"]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_curves"]
     pub fn SSL_CTX_set1_curves(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_int,
@@ -30182,7 +30182,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_curves"]
     pub fn SSL_set1_curves(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_int,
@@ -30190,29 +30190,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_curves_list"]
     pub fn SSL_CTX_set1_curves_list(
         ctx: *mut SSL_CTX,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_curves_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_curves_list"]
     pub fn SSL_set1_curves_list(
         ssl: *mut SSL,
         curves: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_curve_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_curve_id"]
     pub fn SSL_get_curve_id(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_curve_name"]
     pub fn SSL_get_curve_name(curve_id: u16) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_to_bytes"]
     pub fn SSL_to_bytes(
         in_: *const SSL,
         out_data: *mut *mut u8,
@@ -30220,11 +30220,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_from_bytes"]
     pub fn SSL_from_bytes(in_: *const u8, in_len: usize, ctx: *mut SSL_CTX) -> *mut SSL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_groups"]
     pub fn SSL_CTX_set1_groups(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_int,
@@ -30232,7 +30232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_groups"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_groups"]
     pub fn SSL_set1_groups(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_int,
@@ -30240,21 +30240,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_groups_list"]
     pub fn SSL_CTX_set1_groups_list(
         ctx: *mut SSL_CTX,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_groups_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_groups_list"]
     pub fn SSL_set1_groups_list(
         ssl: *mut SSL,
         groups: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify"]
     pub fn SSL_CTX_set_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30267,7 +30267,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify"]
     pub fn SSL_set_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30284,7 +30284,7 @@ pub const ssl_verify_result_t_ssl_verify_invalid: ssl_verify_result_t = 1;
 pub const ssl_verify_result_t_ssl_verify_retry: ssl_verify_result_t = 2;
 pub type ssl_verify_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_custom_verify"]
     pub fn SSL_CTX_set_custom_verify(
         ctx: *mut SSL_CTX,
         mode: ::std::os::raw::c_int,
@@ -30294,7 +30294,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_custom_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_custom_verify"]
     pub fn SSL_set_custom_verify(
         ssl: *mut SSL,
         mode: ::std::os::raw::c_int,
@@ -30304,15 +30304,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_mode"]
     pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_mode"]
     pub fn SSL_get_verify_mode(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_callback"]
     pub fn SSL_CTX_get_verify_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -30323,7 +30323,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_callback"]
     pub fn SSL_get_verify_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -30334,83 +30334,83 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_host"]
     pub fn SSL_set1_host(
         ssl: *mut SSL,
         hostname: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify_depth"]
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify_depth"]
     pub fn SSL_set_verify_depth(ssl: *mut SSL, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_verify_depth"]
     pub fn SSL_CTX_get_verify_depth(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_depth"]
     pub fn SSL_get_verify_depth(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_param"]
     pub fn SSL_CTX_set1_param(
         ctx: *mut SSL_CTX,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_param"]
     pub fn SSL_set1_param(ssl: *mut SSL, param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get0_param"]
     pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_param"]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_purpose"]
     pub fn SSL_CTX_set_purpose(
         ctx: *mut SSL_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_purpose"]
     pub fn SSL_set_purpose(ssl: *mut SSL, purpose: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_trust"]
     pub fn SSL_CTX_set_trust(
         ctx: *mut SSL_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_trust"]
     pub fn SSL_set_trust(ssl: *mut SSL, trust: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_store"]
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_cert_store"]
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_default_verify_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_default_verify_paths"]
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_load_verify_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_load_verify_locations"]
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,
         ca_file: *const ::std::os::raw::c_char,
@@ -30418,19 +30418,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_verify_result"]
     pub fn SSL_get_verify_result(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_from_verify_result"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_from_verify_result"]
     pub fn SSL_alert_from_verify_result(result: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_data_X509_STORE_CTX_idx"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_data_X509_STORE_CTX_idx"]
     pub fn SSL_get_ex_data_X509_STORE_CTX_idx() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_cert_verify_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_cert_verify_callback"]
     pub fn SSL_CTX_set_cert_verify_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30443,51 +30443,51 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_signed_cert_timestamps"]
     pub fn SSL_enable_signed_cert_timestamps(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_signed_cert_timestamps"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_signed_cert_timestamps"]
     pub fn SSL_CTX_enable_signed_cert_timestamps(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_ocsp_stapling"]
     pub fn SSL_enable_ocsp_stapling(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_ocsp_stapling"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_ocsp_stapling"]
     pub fn SSL_CTX_enable_ocsp_stapling(ctx: *mut SSL_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_verify_cert_store"]
     pub fn SSL_CTX_set0_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_verify_cert_store"]
     pub fn SSL_CTX_set1_verify_cert_store(
         ctx: *mut SSL_CTX,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_verify_cert_store"]
     pub fn SSL_set0_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_verify_cert_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_verify_cert_store"]
     pub fn SSL_set1_verify_cert_store(
         ssl: *mut SSL,
         store: *mut X509_STORE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_verify_algorithm_prefs"]
     pub fn SSL_CTX_set_verify_algorithm_prefs(
         ctx: *mut SSL_CTX,
         prefs: *const u16,
@@ -30495,7 +30495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_verify_algorithm_prefs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_verify_algorithm_prefs"]
     pub fn SSL_set_verify_algorithm_prefs(
         ssl: *mut SSL,
         prefs: *const u16,
@@ -30503,87 +30503,87 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_hostflags"]
     pub fn SSL_set_hostflags(ssl: *mut SSL, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_client_CA_list"]
     pub fn SSL_set_client_CA_list(ssl: *mut SSL, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_client_CA_list"]
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, name_list: *mut stack_st_X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set0_client_CAs"]
     pub fn SSL_set0_client_CAs(ssl: *mut SSL, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set0_client_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set0_client_CAs"]
     pub fn SSL_CTX_set0_client_CAs(ctx: *mut SSL_CTX, name_list: *mut stack_st_CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_client_CA_list"]
     pub fn SSL_get_client_CA_list(ssl: *const SSL) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_server_requested_CAs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_server_requested_CAs"]
     pub fn SSL_get0_server_requested_CAs(ssl: *const SSL) -> *const stack_st_CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_client_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_client_CA_list"]
     pub fn SSL_CTX_get_client_CA_list(ctx: *const SSL_CTX) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_client_CA"]
     pub fn SSL_add_client_CA(ssl: *mut SSL, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_client_CA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_client_CA"]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_load_client_CA_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_load_client_CA_file"]
     pub fn SSL_load_client_CA_file(file: *const ::std::os::raw::c_char) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_dup_CA_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_dup_CA_list"]
     pub fn SSL_dup_CA_list(list: *mut stack_st_X509_NAME) -> *mut stack_st_X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_file_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_file_cert_subjects_to_stack"]
     pub fn SSL_add_file_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         file: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_bio_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_bio_cert_subjects_to_stack"]
     pub fn SSL_add_bio_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_host_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_host_name"]
     pub fn SSL_set_tlsext_host_name(
         ssl: *mut SSL,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_servername"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_servername"]
     pub fn SSL_get_servername(
         ssl: *const SSL,
         type_: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_servername_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_servername_type"]
     pub fn SSL_get_servername_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_callback"]
     pub fn SSL_CTX_set_tlsext_servername_callback(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -30596,18 +30596,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_servername_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_servername_arg"]
     pub fn SSL_CTX_set_tlsext_servername_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_SSL_CTX"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_SSL_CTX"]
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_alpn_protos"]
     pub fn SSL_CTX_set_alpn_protos(
         ctx: *mut SSL_CTX,
         protos: *const u8,
@@ -30615,7 +30615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_alpn_protos"]
     pub fn SSL_set_alpn_protos(
         ssl: *mut SSL,
         protos: *const u8,
@@ -30623,7 +30623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_alpn_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_alpn_select_cb"]
     pub fn SSL_CTX_set_alpn_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30640,7 +30640,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_alpn_selected"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_alpn_selected"]
     pub fn SSL_get0_alpn_selected(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30648,11 +30648,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_allow_unknown_alpn_protos"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_allow_unknown_alpn_protos"]
     pub fn SSL_CTX_set_allow_unknown_alpn_protos(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_application_settings"]
     pub fn SSL_add_application_settings(
         ssl: *mut SSL,
         proto: *const u8,
@@ -30662,7 +30662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_peer_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_peer_application_settings"]
     pub fn SSL_get0_peer_application_settings(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30670,7 +30670,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_has_application_settings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_has_application_settings"]
     pub fn SSL_has_application_settings(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub type ssl_cert_compression_func_t = ::std::option::Option<
@@ -30691,7 +30691,7 @@ pub type ssl_cert_decompression_func_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_add_cert_compression_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_add_cert_compression_alg"]
     pub fn SSL_CTX_add_cert_compression_alg(
         ctx: *mut SSL_CTX,
         alg_id: u16,
@@ -30700,7 +30700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_next_protos_advertised_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_next_protos_advertised_cb"]
     pub fn SSL_CTX_set_next_protos_advertised_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30715,7 +30715,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_next_proto_select_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_next_proto_select_cb"]
     pub fn SSL_CTX_set_next_proto_select_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30732,7 +30732,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_next_proto_negotiated"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_next_proto_negotiated"]
     pub fn SSL_get0_next_proto_negotiated(
         ssl: *const SSL,
         out_data: *mut *const u8,
@@ -30740,7 +30740,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_select_next_proto"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_select_next_proto"]
     pub fn SSL_select_next_proto(
         out: *mut *mut u8,
         out_len: *mut u8,
@@ -30751,29 +30751,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tls_channel_id_enabled"]
     pub fn SSL_CTX_set_tls_channel_id_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tls_channel_id_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tls_channel_id_enabled"]
     pub fn SSL_set_tls_channel_id_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_tls_channel_id"]
     pub fn SSL_CTX_set1_tls_channel_id(
         ctx: *mut SSL_CTX,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_tls_channel_id"]
     pub fn SSL_set1_tls_channel_id(
         ssl: *mut SSL,
         private_key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tls_channel_id"]
     pub fn SSL_get_tls_channel_id(ssl: *mut SSL, out: *mut u8, max_out: usize) -> usize;
 }
 #[repr(C)]
@@ -30850,29 +30850,29 @@ pub type sk_SRTP_PROTECTION_PROFILE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_srtp_profiles"]
     pub fn SSL_CTX_set_srtp_profiles(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_srtp_profiles"]
     pub fn SSL_set_srtp_profiles(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_srtp_profiles"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_srtp_profiles"]
     pub fn SSL_get_srtp_profiles(ssl: *const SSL) -> *const stack_st_SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_selected_srtp_profile"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_selected_srtp_profile"]
     pub fn SSL_get_selected_srtp_profile(ssl: *mut SSL) -> *const SRTP_PROTECTION_PROFILE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_psk_client_callback"]
     pub fn SSL_CTX_set_psk_client_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30888,7 +30888,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_psk_client_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_psk_client_callback"]
     pub fn SSL_set_psk_client_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -30904,7 +30904,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_psk_server_callback"]
     pub fn SSL_CTX_set_psk_server_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -30918,7 +30918,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_psk_server_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_psk_server_callback"]
     pub fn SSL_set_psk_server_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -30932,29 +30932,29 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_use_psk_identity_hint"]
     pub fn SSL_CTX_use_psk_identity_hint(
         ctx: *mut SSL_CTX,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_use_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_use_psk_identity_hint"]
     pub fn SSL_use_psk_identity_hint(
         ssl: *mut SSL,
         identity_hint: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_psk_identity_hint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_psk_identity_hint"]
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_psk_identity"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_psk_identity"]
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_delegated_credential"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_delegated_credential"]
     pub fn SSL_set1_delegated_credential(
         ssl: *mut SSL,
         dc: *mut CRYPTO_BUFFER,
@@ -30963,7 +30963,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_delegated_credential_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_delegated_credential_used"]
     pub fn SSL_delegated_credential_used(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 pub const ssl_encryption_level_t_ssl_encryption_initial: ssl_encryption_level_t = 0;
@@ -31076,22 +31076,22 @@ fn bindgen_test_layout_ssl_quic_method_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_max_handshake_flight_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_max_handshake_flight_len"]
     pub fn SSL_quic_max_handshake_flight_len(
         ssl: *const SSL,
         level: ssl_encryption_level_t,
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_read_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_read_level"]
     pub fn SSL_quic_read_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_quic_write_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_quic_write_level"]
     pub fn SSL_quic_write_level(ssl: *const SSL) -> ssl_encryption_level_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_provide_quic_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_provide_quic_data"]
     pub fn SSL_provide_quic_data(
         ssl: *mut SSL,
         level: ssl_encryption_level_t,
@@ -31100,25 +31100,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_process_quic_post_handshake"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_process_quic_post_handshake"]
     pub fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_quic_method"]
     pub fn SSL_CTX_set_quic_method(
         ctx: *mut SSL_CTX,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_method"]
     pub fn SSL_set_quic_method(
         ssl: *mut SSL,
         quic_method: *const SSL_QUIC_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_transport_params"]
     pub fn SSL_set_quic_transport_params(
         ssl: *mut SSL,
         params: *const u8,
@@ -31126,7 +31126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_quic_transport_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_quic_transport_params"]
     pub fn SSL_get_peer_quic_transport_params(
         ssl: *const SSL,
         out_params: *mut *const u8,
@@ -31134,11 +31134,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_use_legacy_codepoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_use_legacy_codepoint"]
     pub fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_quic_early_data_context"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_quic_early_data_context"]
     pub fn SSL_set_quic_early_data_context(
         ssl: *mut SSL,
         context: *const u8,
@@ -31146,35 +31146,35 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_early_data_enabled"]
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_early_data_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_early_data_enabled"]
     pub fn SSL_set_early_data_enabled(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_in_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_in_early_data"]
     pub fn SSL_in_early_data(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_early_data_capable"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_early_data_capable"]
     pub fn SSL_SESSION_early_data_capable(session: *const SSL_SESSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_copy_without_early_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_copy_without_early_data"]
     pub fn SSL_SESSION_copy_without_early_data(session: *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_data_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_data_accepted"]
     pub fn SSL_early_data_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_reset_early_data_reject"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_reset_early_data_reject"]
     pub fn SSL_reset_early_data_reject(ssl: *mut SSL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ticket_age_skew"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ticket_age_skew"]
     pub fn SSL_get_ticket_age_skew(ssl: *const SSL) -> i32;
 }
 pub const ssl_early_data_reason_t_ssl_early_data_unknown: ssl_early_data_reason_t = 0;
@@ -31196,21 +31196,21 @@ pub const ssl_early_data_reason_t_ssl_early_data_alps_mismatch: ssl_early_data_r
 pub const ssl_early_data_reason_t_ssl_early_data_reason_max_value: ssl_early_data_reason_t = 14;
 pub type ssl_early_data_reason_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_early_data_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_early_data_reason"]
     pub fn SSL_get_early_data_reason(ssl: *const SSL) -> ssl_early_data_reason_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_data_reason_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_data_reason_string"]
     pub fn SSL_early_data_reason_string(
         reason: ssl_early_data_reason_t,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_enable_ech_grease"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_enable_ech_grease"]
     pub fn SSL_set_enable_ech_grease(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_ech_config_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_ech_config_list"]
     pub fn SSL_set1_ech_config_list(
         ssl: *mut SSL,
         ech_config_list: *const u8,
@@ -31218,7 +31218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ech_name_override"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ech_name_override"]
     pub fn SSL_get0_ech_name_override(
         ssl: *const SSL,
         out_name: *mut *const ::std::os::raw::c_char,
@@ -31226,7 +31226,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get0_ech_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get0_ech_retry_configs"]
     pub fn SSL_get0_ech_retry_configs(
         ssl: *const SSL,
         out_retry_configs: *mut *const u8,
@@ -31234,7 +31234,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_marshal_ech_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_marshal_ech_config"]
     pub fn SSL_marshal_ech_config(
         out: *mut *mut u8,
         out_len: *mut usize,
@@ -31245,19 +31245,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_new"]
     pub fn SSL_ECH_KEYS_new() -> *mut SSL_ECH_KEYS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_up_ref"]
     pub fn SSL_ECH_KEYS_up_ref(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_free"]
     pub fn SSL_ECH_KEYS_free(keys: *mut SSL_ECH_KEYS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_add"]
     pub fn SSL_ECH_KEYS_add(
         keys: *mut SSL_ECH_KEYS,
         is_retry_config: ::std::os::raw::c_int,
@@ -31267,12 +31267,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_has_duplicate_config_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_has_duplicate_config_id"]
     pub fn SSL_ECH_KEYS_has_duplicate_config_id(keys: *const SSL_ECH_KEYS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ECH_KEYS_marshal_retry_configs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ECH_KEYS_marshal_retry_configs"]
     pub fn SSL_ECH_KEYS_marshal_retry_configs(
         keys: *const SSL_ECH_KEYS,
         out: *mut *mut u8,
@@ -31280,34 +31280,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_ech_keys"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_ech_keys"]
     pub fn SSL_CTX_set1_ech_keys(
         ctx: *mut SSL_CTX,
         keys: *mut SSL_ECH_KEYS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_ech_accepted"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_ech_accepted"]
     pub fn SSL_ech_accepted(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_type_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_type_string_long"]
     pub fn SSL_alert_type_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_desc_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_desc_string_long"]
     pub fn SSL_alert_desc_string_long(
         value: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_send_fatal_alert"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_send_fatal_alert"]
     pub fn SSL_send_fatal_alert(ssl: *mut SSL, alert: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_ex_data"]
     pub fn SSL_set_ex_data(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -31315,14 +31315,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_data"]
     pub fn SSL_get_ex_data(
         ssl: *const SSL,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ex_new_index"]
     pub fn SSL_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31332,7 +31332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_set_ex_data"]
     pub fn SSL_SESSION_set_ex_data(
         session: *mut SSL_SESSION,
         idx: ::std::os::raw::c_int,
@@ -31340,14 +31340,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ex_data"]
     pub fn SSL_SESSION_get_ex_data(
         session: *const SSL_SESSION,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_SESSION_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_SESSION_get_ex_new_index"]
     pub fn SSL_SESSION_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31357,7 +31357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_ex_data"]
     pub fn SSL_CTX_set_ex_data(
         ctx: *mut SSL_CTX,
         idx: ::std::os::raw::c_int,
@@ -31365,14 +31365,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ex_data"]
     pub fn SSL_CTX_get_ex_data(
         ctx: *const SSL_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_ex_new_index"]
     pub fn SSL_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -31382,7 +31382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_ivs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_ivs"]
     pub fn SSL_get_ivs(
         ssl: *const SSL,
         out_read_iv: *mut *const u8,
@@ -31391,11 +31391,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_key_block_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_key_block_len"]
     pub fn SSL_get_key_block_len(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_generate_key_block"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_generate_key_block"]
     pub fn SSL_generate_key_block(
         ssl: *const SSL,
         out: *mut u8,
@@ -31403,26 +31403,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_read_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_read_sequence"]
     pub fn SSL_get_read_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_write_sequence"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_write_sequence"]
     pub fn SSL_get_write_sequence(ssl: *const SSL) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_record_protocol_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_record_protocol_version"]
     pub fn SSL_CTX_set_record_protocol_version(
         ctx: *mut SSL_CTX,
         version: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_serialize_capabilities"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_serialize_capabilities"]
     pub fn SSL_serialize_capabilities(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_request_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_request_handshake_hints"]
     pub fn SSL_request_handshake_hints(
         ssl: *mut SSL,
         client_hello: *const u8,
@@ -31432,11 +31432,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_serialize_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_serialize_handshake_hints"]
     pub fn SSL_serialize_handshake_hints(ssl: *const SSL, out: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_handshake_hints"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_handshake_hints"]
     pub fn SSL_set_handshake_hints(
         ssl: *mut SSL,
         hints: *const u8,
@@ -31444,7 +31444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback"]
     pub fn SSL_CTX_set_msg_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31461,11 +31461,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_msg_callback_arg"]
     pub fn SSL_CTX_set_msg_callback_arg(ctx: *mut SSL_CTX, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_msg_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_msg_callback"]
     pub fn SSL_set_msg_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31482,11 +31482,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_msg_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_msg_callback_arg"]
     pub fn SSL_set_msg_callback_arg(ssl: *mut SSL, arg: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_keylog_callback"]
     pub fn SSL_CTX_set_keylog_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31495,7 +31495,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_keylog_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_keylog_callback"]
     pub fn SSL_CTX_get_keylog_callback(
         ctx: *const SSL_CTX,
     ) -> ::std::option::Option<
@@ -31503,14 +31503,14 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_current_time_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_current_time_cb"]
     pub fn SSL_CTX_set_current_time_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<unsafe extern "C" fn(ssl: *const SSL, out_clock: *mut timeval)>,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_shed_handshake_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_shed_handshake_config"]
     pub fn SSL_set_shed_handshake_config(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_never: ssl_renegotiate_mode_t = 0;
@@ -31520,46 +31520,46 @@ pub const ssl_renegotiate_mode_t_ssl_renegotiate_ignore: ssl_renegotiate_mode_t 
 pub const ssl_renegotiate_mode_t_ssl_renegotiate_explicit: ssl_renegotiate_mode_t = 4;
 pub type ssl_renegotiate_mode_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_renegotiate_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_renegotiate_mode"]
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_renegotiate"]
     pub fn SSL_renegotiate(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_renegotiate_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_renegotiate_pending"]
     pub fn SSL_renegotiate_pending(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_total_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_total_renegotiations"]
     pub fn SSL_total_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_max_cert_list"]
     pub fn SSL_CTX_get_max_cert_list(ctx: *const SSL_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_cert_list"]
     pub fn SSL_CTX_set_max_cert_list(ctx: *mut SSL_CTX, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_max_cert_list"]
     pub fn SSL_get_max_cert_list(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_cert_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_cert_list"]
     pub fn SSL_set_max_cert_list(ssl: *mut SSL, max_cert_list: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_max_send_fragment"]
     pub fn SSL_CTX_set_max_send_fragment(
         ctx: *mut SSL_CTX,
         max_send_fragment: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_max_send_fragment"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_max_send_fragment"]
     pub fn SSL_set_max_send_fragment(
         ssl: *mut SSL,
         max_send_fragment: usize,
@@ -31753,7 +31753,7 @@ pub const ssl_select_cert_result_t_ssl_select_cert_retry: ssl_select_cert_result
 pub const ssl_select_cert_result_t_ssl_select_cert_error: ssl_select_cert_result_t = -1;
 pub type ssl_select_cert_result_t = ::std::os::raw::c_int;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_early_callback_ctx_extension_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_early_callback_ctx_extension_get"]
     pub fn SSL_early_callback_ctx_extension_get(
         client_hello: *const SSL_CLIENT_HELLO,
         extension_type: u16,
@@ -31762,7 +31762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_select_certificate_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_select_certificate_cb"]
     pub fn SSL_CTX_set_select_certificate_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31771,7 +31771,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_dos_protection_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_dos_protection_cb"]
     pub fn SSL_CTX_set_dos_protection_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31780,19 +31780,19 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_reverify_on_resume"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_reverify_on_resume"]
     pub fn SSL_CTX_set_reverify_on_resume(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_enforce_rsa_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_enforce_rsa_key_usage"]
     pub fn SSL_set_enforce_rsa_key_usage(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_was_key_usage_invalid"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_was_key_usage_invalid"]
     pub fn SSL_was_key_usage_invalid(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_info_callback"]
     pub fn SSL_CTX_set_info_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -31805,7 +31805,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_info_callback"]
     pub fn SSL_CTX_get_info_callback(
         ctx: *mut SSL_CTX,
     ) -> ::std::option::Option<
@@ -31817,7 +31817,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_info_callback"]
     pub fn SSL_set_info_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -31830,7 +31830,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_info_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_info_callback"]
     pub fn SSL_get_info_callback(
         ssl: *const SSL,
     ) -> ::std::option::Option<
@@ -31842,77 +31842,77 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state_string_long"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state_string_long"]
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shutdown"]
     pub fn SSL_get_shutdown(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_signature_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_signature_algorithm"]
     pub fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_client_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_client_random"]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_server_random"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_server_random"]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut u8, max_out: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_pending_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_pending_cipher"]
     pub fn SSL_get_pending_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_set_retain_only_sha256_of_client_certs(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_retain_only_sha256_of_client_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_retain_only_sha256_of_client_certs"]
     pub fn SSL_CTX_set_retain_only_sha256_of_client_certs(
         ctx: *mut SSL_CTX,
         enable: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_grease_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_grease_enabled"]
     pub fn SSL_CTX_set_grease_enabled(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_permute_extensions"]
     pub fn SSL_CTX_set_permute_extensions(ctx: *mut SSL_CTX, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_permute_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_permute_extensions"]
     pub fn SSL_set_permute_extensions(ssl: *mut SSL, enabled: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_max_seal_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_max_seal_overhead"]
     pub fn SSL_max_seal_overhead(ssl: *const SSL) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_false_start_allowed_without_alpn"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_false_start_allowed_without_alpn"]
     pub fn SSL_CTX_set_false_start_allowed_without_alpn(
         ctx: *mut SSL_CTX,
         allowed: ::std::os::raw::c_int,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_used_hello_retry_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_used_hello_retry_request"]
     pub fn SSL_used_hello_retry_request(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_jdk11_workaround"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_jdk11_workaround"]
     pub fn SSL_set_jdk11_workaround(ssl: *mut SSL, enable: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_library_init"]
     pub fn SSL_library_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_description"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_description"]
     pub fn SSL_CIPHER_description(
         cipher: *const SSL_CIPHER,
         buf: *mut ::std::os::raw::c_char,
@@ -31920,11 +31920,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_version"]
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_rfc_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_rfc_name"]
     pub fn SSL_CIPHER_get_rfc_name(cipher: *const SSL_CIPHER) -> *mut ::std::os::raw::c_char;
 }
 pub type COMP_METHOD = ::std::os::raw::c_void;
@@ -31935,126 +31935,126 @@ pub struct stack_st_SSL_COMP {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_compression_methods"]
     pub fn SSL_COMP_get_compression_methods() -> *mut stack_st_SSL_COMP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_add_compression_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_add_compression_method"]
     pub fn SSL_COMP_add_compression_method(
         id: ::std::os::raw::c_int,
         cm: *mut COMP_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_name"]
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get0_name"]
     pub fn SSL_COMP_get0_name(comp: *const SSL_COMP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_get_id"]
     pub fn SSL_COMP_get_id(comp: *const SSL_COMP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_COMP_free_compression_methods"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_COMP_free_compression_methods"]
     pub fn SSL_COMP_free_compression_methods();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_method"]
     pub fn SSLv23_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_method"]
     pub fn TLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_method"]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_method"]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_method"]
     pub fn DTLSv1_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_method"]
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_server_method"]
     pub fn TLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLS_client_method"]
     pub fn TLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_server_method"]
     pub fn SSLv23_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSLv23_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSLv23_client_method"]
     pub fn SSLv23_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_server_method"]
     pub fn TLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_client_method"]
     pub fn TLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_server_method"]
     pub fn TLSv1_1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_1_client_method"]
     pub fn TLSv1_1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_server_method"]
     pub fn TLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_TLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_TLSv1_2_client_method"]
     pub fn TLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_server_method"]
     pub fn DTLS_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLS_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLS_client_method"]
     pub fn DTLS_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_server_method"]
     pub fn DTLSv1_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_client_method"]
     pub fn DTLSv1_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_server_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_server_method"]
     pub fn DTLSv1_2_server_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_DTLSv1_2_client_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_DTLSv1_2_client_method"]
     pub fn DTLSv1_2_client_method() -> *const SSL_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_clear"]
     pub fn SSL_clear(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa_callback"]
     pub fn SSL_CTX_set_tmp_rsa_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32067,7 +32067,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_rsa_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_rsa_callback"]
     pub fn SSL_set_tmp_rsa_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32080,98 +32080,98 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect"]
     pub fn SSL_CTX_sess_connect(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect_good"]
     pub fn SSL_CTX_sess_connect_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_connect_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_connect_renegotiate"]
     pub fn SSL_CTX_sess_connect_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept"]
     pub fn SSL_CTX_sess_accept(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept_renegotiate"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept_renegotiate"]
     pub fn SSL_CTX_sess_accept_renegotiate(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_accept_good"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_accept_good"]
     pub fn SSL_CTX_sess_accept_good(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_hits"]
     pub fn SSL_CTX_sess_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_cb_hits"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_cb_hits"]
     pub fn SSL_CTX_sess_cb_hits(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_misses"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_misses"]
     pub fn SSL_CTX_sess_misses(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_timeouts"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_timeouts"]
     pub fn SSL_CTX_sess_timeouts(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_sess_cache_full"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_sess_cache_full"]
     pub fn SSL_CTX_sess_cache_full(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_cutthrough_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_cutthrough_complete"]
     pub fn SSL_cutthrough_complete(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_num_renegotiations"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_num_renegotiations"]
     pub fn SSL_num_renegotiations(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_need_tmp_RSA"]
     pub fn SSL_CTX_need_tmp_RSA(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_need_tmp_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_need_tmp_RSA"]
     pub fn SSL_need_tmp_RSA(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_rsa"]
     pub fn SSL_CTX_set_tmp_rsa(ctx: *mut SSL_CTX, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_rsa"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_rsa"]
     pub fn SSL_set_tmp_rsa(ssl: *mut SSL, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_read_ahead"]
     pub fn SSL_CTX_get_read_ahead(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_read_ahead"]
     pub fn SSL_CTX_set_read_ahead(
         ctx: *mut SSL_CTX,
         yes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_read_ahead"]
     pub fn SSL_get_read_ahead(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_read_ahead"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_read_ahead"]
     pub fn SSL_set_read_ahead(ssl: *mut SSL, yes: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_state"]
     pub fn SSL_set_state(ssl: *mut SSL, state: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shared_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shared_ciphers"]
     pub fn SSL_get_shared_ciphers(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_char,
@@ -32179,7 +32179,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_shared_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_shared_sigalgs"]
     pub fn SSL_get_shared_sigalgs(
         ssl: *mut SSL,
         idx: ::std::os::raw::c_int,
@@ -32191,11 +32191,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_SSL_SESSION"]
     pub fn i2d_SSL_SESSION(in_: *mut SSL_SESSION, pp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_SSL_SESSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_SSL_SESSION"]
     pub fn d2i_SSL_SESSION(
         a: *mut *mut SSL_SESSION,
         pp: *mut *const u8,
@@ -32203,61 +32203,61 @@ extern "C" {
     ) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_i2d_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_i2d_SSL_SESSION_bio"]
     pub fn i2d_SSL_SESSION_bio(bio: *mut BIO, session: *const SSL_SESSION)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_d2i_SSL_SESSION_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_d2i_SSL_SESSION_bio"]
     pub fn d2i_SSL_SESSION_bio(bio: *mut BIO, out: *mut *mut SSL_SESSION) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_load_SSL_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_load_SSL_strings"]
     pub fn ERR_load_SSL_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_load_error_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_load_error_strings"]
     pub fn SSL_load_error_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_use_srtp"]
     pub fn SSL_CTX_set_tlsext_use_srtp(
         ctx: *mut SSL_CTX,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_use_srtp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_use_srtp"]
     pub fn SSL_set_tlsext_use_srtp(
         ssl: *mut SSL,
         profiles: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_compression"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_compression"]
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_current_expansion"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_current_expansion"]
     pub fn SSL_get_current_expansion(ssl: *mut SSL) -> *const COMP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_server_tmp_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_server_tmp_key"]
     pub fn SSL_get_server_tmp_key(
         ssl: *mut SSL,
         out_key: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh"]
     pub fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_dh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_dh"]
     pub fn SSL_set_tmp_dh(ssl: *mut SSL, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_dh_callback"]
     pub fn SSL_CTX_set_tmp_dh_callback(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32270,7 +32270,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_dh_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_dh_callback"]
     pub fn SSL_set_tmp_dh_callback(
         ssl: *mut SSL,
         cb: ::std::option::Option<
@@ -32283,7 +32283,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs"]
     pub fn SSL_CTX_set1_sigalgs(
         ctx: *mut SSL_CTX,
         values: *const ::std::os::raw::c_int,
@@ -32291,7 +32291,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_sigalgs"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_sigalgs"]
     pub fn SSL_set1_sigalgs(
         ssl: *mut SSL,
         values: *const ::std::os::raw::c_int,
@@ -32299,25 +32299,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set1_sigalgs_list"]
     pub fn SSL_CTX_set1_sigalgs_list(
         ctx: *mut SSL_CTX,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set1_sigalgs_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set1_sigalgs_list"]
     pub fn SSL_set1_sigalgs_list(
         ssl: *mut SSL,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_get_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_get_security_level"]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_security_level"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_security_level"]
     pub fn SSL_CTX_set_security_level(ctx: *const SSL_CTX, level: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -32397,26 +32397,26 @@ pub type sk_SSL_COMP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_cache_hit"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_cache_hit"]
     pub fn SSL_cache_hit(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_default_timeout"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_default_timeout"]
     pub fn SSL_get_default_timeout(ssl: *const SSL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_version"]
     pub fn SSL_get_version(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_cipher_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_cipher_list"]
     pub fn SSL_get_cipher_list(
         ssl: *const SSL,
         n: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_client_cert_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_client_cert_cb"]
     pub fn SSL_CTX_set_client_cert_cb(
         ctx: *mut SSL_CTX,
         cb: ::std::option::Option<
@@ -32429,11 +32429,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_want"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_want"]
     pub fn SSL_want(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_finished"]
     pub fn SSL_get_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32441,7 +32441,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_peer_finished"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_peer_finished"]
     pub fn SSL_get_peer_finished(
         ssl: *const SSL,
         buf: *mut ::std::os::raw::c_void,
@@ -32449,15 +32449,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_type_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_type_string"]
     pub fn SSL_alert_type_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_alert_desc_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_alert_desc_string"]
     pub fn SSL_alert_desc_string(value: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state_string"]
     pub fn SSL_state_string(ssl: *const SSL) -> *const ::std::os::raw::c_char;
 }
 #[repr(C)]
@@ -32467,42 +32467,42 @@ pub struct ssl_conf_ctx_st {
 }
 pub type SSL_CONF_CTX = ssl_conf_ctx_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_state"]
     pub fn SSL_state(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_shutdown"]
     pub fn SSL_set_shutdown(ssl: *mut SSL, mode: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tmp_ecdh"]
     pub fn SSL_CTX_set_tmp_ecdh(ctx: *mut SSL_CTX, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tmp_ecdh"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tmp_ecdh"]
     pub fn SSL_set_tmp_ecdh(ssl: *mut SSL, ec_key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_add_dir_cert_subjects_to_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_add_dir_cert_subjects_to_stack"]
     pub fn SSL_add_dir_cert_subjects_to_stack(
         out: *mut stack_st_X509_NAME,
         dir: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_enable_tls_channel_id"]
     pub fn SSL_CTX_enable_tls_channel_id(ctx: *mut SSL_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_enable_tls_channel_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_enable_tls_channel_id"]
     pub fn SSL_enable_tls_channel_id(ssl: *mut SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_f_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_f_ssl"]
     pub fn BIO_f_ssl() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_BIO_set_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_BIO_set_ssl"]
     pub fn BIO_set_ssl(
         bio: *mut BIO,
         ssl: *mut SSL,
@@ -32510,33 +32510,33 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_session"]
     pub fn SSL_get_session(ssl: *const SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get1_session"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get1_session"]
     pub fn SSL_get1_session(ssl: *mut SSL) -> *mut SSL_SESSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_OPENSSL_init_ssl"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_OPENSSL_init_ssl"]
     pub fn OPENSSL_init_ssl(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_status_type"]
     pub fn SSL_set_tlsext_status_type(
         ssl: *mut SSL,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tlsext_status_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tlsext_status_type"]
     pub fn SSL_get_tlsext_status_type(ssl: *const SSL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_set_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_set_tlsext_status_ocsp_resp"]
     pub fn SSL_set_tlsext_status_ocsp_resp(
         ssl: *mut SSL,
         resp: *mut u8,
@@ -32544,11 +32544,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_get_tlsext_status_ocsp_resp"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_get_tlsext_status_ocsp_resp"]
     pub fn SSL_get_tlsext_status_ocsp_resp(ssl: *const SSL, out: *mut *const u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_cb"]
     pub fn SSL_CTX_set_tlsext_status_cb(
         ctx: *mut SSL_CTX,
         callback: ::std::option::Option<
@@ -32560,18 +32560,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CTX_set_tlsext_status_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CTX_set_tlsext_status_arg"]
     pub fn SSL_CTX_set_tlsext_status_arg(
         ctx: *mut SSL_CTX,
         arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_SSL_CIPHER_get_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_SSL_CIPHER_get_value"]
     pub fn SSL_CIPHER_get_value(cipher: *const SSL_CIPHER) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -32587,15 +32587,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_12_10_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_12_11_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];


### PR DESCRIPTION
### Issues:
Addresses #466

### Description of changes: 
* Updaate aws-lc-fips-sys to v0.12.11. Aligned with [AWS-LC-FIPS v2.0.14](https://github.com/aws/aws-lc/releases/tag/AWS-LC-FIPS-2.0.14).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
