### PR TITLE
Build aws-lc w/ C11

### DIFF
--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -137,6 +137,8 @@ impl CmakeBuilder {
             cmake_cfg.define("ASAN", "1");
         }
 
+        cmake_cfg.define("CMAKE_C_STANDARD", "11");
+
         // Allow environment to specify CMake toolchain.
         if option_env("CMAKE_TOOLCHAIN_FILE").is_some()
             || option_env(format!("CMAKE_TOOLCHAIN_FILE_{}", target_underscored())).is_some()

--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -100,7 +100,7 @@ impl CcBuilder {
         let mut cc_build = cc::Build::default();
         cc_build
             .out_dir(&self.out_dir)
-            .flag("-std=c99")
+            .flag("-std=c11")
             .flag("-Wno-unused-parameter")
             .cpp(false)
             .shared_flag(false)

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -133,6 +133,8 @@ impl CmakeBuilder {
             cmake_cfg.define("ASAN", "1");
         }
 
+        cmake_cfg.define("CMAKE_C_STANDARD", "11");
+
         // Allow environment to specify CMake toolchain.
         if let Some(toolchain) = option_env("CMAKE_TOOLCHAIN_FILE").or(option_env(format!(
             "CMAKE_TOOLCHAIN_FILE_{}",


### PR DESCRIPTION
### Description of changes: 
* Performance may improve on some platforms when AWS-LC's implementation can use [C11 atomics](https://github.com/aws/aws-lc/blob/808f8329177fb2da7f5d757036fbab30fcbd5a2a/crypto/refcount_c11.c).
* Inspired by the upstream PR: https://github.com/aws/aws-lc/pull/1729

### Call-outs:
Clang/GCC compiler versions released in the past ~decade support C11 atomics:
* Clang has supported C11 atomics since [release 3.1](https://releases.llvm.org/3.1/docs/ReleaseNotes.html) ([22 May 2012](https://releases.llvm.org/)).
* GCC has supported C11 atomics since [release 4.9](https://gcc.gnu.org/wiki/C11Status) ([April 22, 2014](https://gcc.gnu.org/gcc-4.9/))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
