### PR TITLE
Update aws-lc-sys to AWS-LC v1.33.0

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -46,7 +46,7 @@ fips = ["dep:aws-lc-fips-sys"]
 
 [dependencies]
 untrusted = { version = "0.7.1", optional = true }
-aws-lc-sys = { version = "0.20.0", path = "../aws-lc-sys", optional = true }
+aws-lc-sys = { version = "0.22.0", path = "../aws-lc-sys", optional = true }
 aws-lc-fips-sys = { version = "0.12.0", path = "../aws-lc-fips-sys", optional = true }
 zeroize = { version = "1.7", features = ["zeroize_derive"] }
 mirai-annotations = "1.12.0"

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "aws-lc-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. It іs based on code from the Google BoringSSL project and the OpenSSL project."
-version = "0.20.1"
-links = "aws_lc_0_20_1"
+version = "0.21.0"
+links = "aws_lc_0_21_0"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"


### PR DESCRIPTION
## What's Changed
* Added options to x509 tool by @ecdeye in https://github.com/aws/aws-lc/pull/1696
* Add support to detect Neoverse V2 cores by @andrewhop in https://github.com/aws/aws-lc/pull/1706
* Move OCSP functions for Ruby out of internal.h by @samuel40791765 in https://github.com/aws/aws-lc/pull/1704
* Add aes-256-xts to EVP_get_cipherbyname by @torben-hansen in https://github.com/aws/aws-lc/pull/1707
* Match using CMAKE_SYSTEM_PROCESSOR_LOWER by @justsmth in https://github.com/aws/aws-lc/pull/1709
* Update MySQL to 9.0.0 by @skmcgrail in https://github.com/aws/aws-lc/pull/1685
* [EC] Unify scalar multiplication for P-256/384/521 by @dkostic in https://github.com/aws/aws-lc/pull/1693
* Adds const qualifier to ciphertext parameter in EVP_PKEY_decapsulate by @maddeleine in https://github.com/aws/aws-lc/pull/1713
* Upstream merge 2024 06 24 by @nebeid in https://github.com/aws/aws-lc/pull/1661
* NIST SP 800-108r1-upd1: KDF Counter Implementation by @skmcgrail in https://github.com/aws/aws-lc/pull/1644
* Upstream merge 2024 07 09 by @nebeid in https://github.com/aws/aws-lc/pull/1694
* Design for support of HMAC precomputed keys by @fabrice102 in https://github.com/aws/aws-lc/pull/1574
* Fix for select point from table in ec_nistp scalar_mul by @dkostic in https://github.com/aws/aws-lc/pull/1719
* X509toolcomparison by @ecdeye in https://github.com/aws/aws-lc/pull/1714
* AWS-LC s2n-bignum update 2024-07-22 by @dkostic in https://github.com/aws/aws-lc/pull/1718
* Add OpenVPN to CI by @smittals2 in https://github.com/aws/aws-lc/pull/1705
* Lower required Go version, add CI test for specific version by @andrewhop in https://github.com/aws/aws-lc/pull/1717
* ec2-test-framework enhancements and graviton 4 testing  by @samuel40791765 in https://github.com/aws/aws-lc/pull/1715
* sha + chacha: Move AArch64/X86-64 dispatching to C. by @justsmth in https://github.com/aws/aws-lc/pull/1625
* Show number of pruned ec2 instances in dashboard by @samuel40791765 in https://github.com/aws/aws-lc/pull/1728
* rsa and md5 tools by @ecdeye in https://github.com/aws/aws-lc/pull/1722
* FIPS 203 IPD update: ML-KEM-IPD-768 and ML-KEM-IPD-1024 by @jakemas in https://github.com/aws/aws-lc/pull/1724
* bump mysql CI to 9.0.1 by @samuel40791765 in https://github.com/aws/aws-lc/pull/1727
* Support utility OCSP request functions by @samuel40791765 in https://github.com/aws/aws-lc/pull/1708
* add support for OCSP_SINGLERESP functions by @samuel40791765 in https://github.com/aws/aws-lc/pull/1703
* Prepare Release for v1.33.0  by @skmcgrail in https://github.com/aws/aws-lc/pull/1734
* Implement BIO_puts and add callback function support to BIO_puts,gets,ctrl by @kexgaber in https://github.com/aws/aws-lc/pull/1721

**Full Changelog**: https://github.com/aws/aws-lc/compare/v1.32.0...v1.33.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
