### PR TITLE
Fix rustls integ test

### DIFF
--- a/aws-lc-rs/scripts/run-rustls-integration.sh
+++ b/aws-lc-rs/scripts/run-rustls-integration.sh
@@ -72,7 +72,6 @@ popd &>/dev/null # "${RUSTLS_WEBPKI_DIR}"
 
 pushd "${RUSTLS_DIR}"
 git checkout "${RUSTLS_COMMIT}"
-pushd ./rustls
 # Update the Cargo.toml to use the GitHub repository reference under test.
 RUSTLS_RCGEN_STRING="^rcgen = { .* }"
 RUSTLS_RCGEN_PATH_STRING="rcgen = { path = \"${RUSTLS_RCGEN_DIR}/rcgen\" , default-features = false, features = [\"aws_lc_rs\", \"pem\"] }"
@@ -88,6 +87,8 @@ fi
 # Trigger Cargo to generate the lock file
 cargo update
 cargo update "aws-lc-rs@${AWS_LC_RS_VERSION}"
+pushd ./rustls
+
 # Print the dependency tree for debug purposes, if we did everything right there
 # should only be one aws-lc-rs version. Otherwise this will fail sine there are multiple versions
 cargo tree -i aws-lc-rs --features aws_lc_rs


### PR DESCRIPTION
### Description of changes: 
* 🤦 Path dependency on "aws-lc-rs" needed to be set for all crates in the rustls repo.

### Callout
* Previous failure can be seen here: https://github.com/aws/aws-lc-rs/actions/runs/10289906212/job/28478656925?pr=492#step:6:1775

### Testing
* Success can be seen here: https://github.com/aws/aws-lc-rs/actions/runs/10357629682/job/28670070690?pr=493

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
