### PR TITLE
First parameter to EVP_MD_CTX_copy should not be initialized

### DIFF
--- a/aws-lc-rs/src/digest/digest_ctx.rs
+++ b/aws-lc-rs/src/digest/digest_ctx.rs
@@ -59,7 +59,8 @@ impl DigestContext {
     fn try_clone(&self) -> Result<Self, &'static str> {
         let mut dc = MaybeUninit::<EVP_MD_CTX>::uninit();
         unsafe {
-            EVP_MD_CTX_init(dc.as_mut_ptr());
+            // The first parameter of `EVP_MD_CTX_copy` should not be initialized.
+            // https://github.com/aws/aws-lc/blob/98ccf4a316401112943bed604562102ad52efac6/include/openssl/digest.h#L280
             if 1 != EVP_MD_CTX_copy(dc.as_mut_ptr(), self.as_ptr()) {
                 return Err("EVP_MD_CTX_copy failed");
             };


### PR DESCRIPTION
### Description of changes: 
* The first parameter of `EVP_MD_CTX_copy` should not be initialized


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
