### PR TITLE
Block::from can consume its argument

### DIFF
--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -145,7 +145,7 @@ fn cipher_new_mask(
     cipher_key: &SymmetricCipherKey,
     sample: Sample,
 ) -> Result<[u8; 5], error::Unspecified> {
-    let block = block::Block::from(&sample);
+    let block = block::Block::from(sample);
 
     let encrypted_block = match cipher_key {
         SymmetricCipherKey::Aes128 { enc_key, .. } | SymmetricCipherKey::Aes256 { enc_key, .. } => {

--- a/aws-lc-rs/src/cipher/aes.rs
+++ b/aws-lc-rs/src/cipher/aes.rs
@@ -29,6 +29,6 @@ pub(crate) fn encrypt_block_aes(aes_key: &AES_KEY, block: Block) -> Block {
             AES_ENCRYPT,
         ));
 
-        Block::from(&cipher_text.assume_init())
+        Block::from(cipher_text.assume_init())
     }
 }

--- a/aws-lc-rs/src/cipher/block.rs
+++ b/aws-lc-rs/src/cipher/block.rs
@@ -23,10 +23,10 @@ impl Block {
     }
 }
 
-impl From<&'_ [u8; BLOCK_LEN]> for Block {
+impl From<[u8; BLOCK_LEN]> for Block {
     #[inline]
-    fn from(bytes: &[u8; BLOCK_LEN]) -> Self {
-        unsafe { core::mem::transmute_copy(bytes) }
+    fn from(bytes: [u8; BLOCK_LEN]) -> Self {
+        unsafe { core::mem::transmute(bytes) }
     }
 }
 
@@ -40,11 +40,10 @@ impl AsRef<[u8; BLOCK_LEN]> for Block {
 
 #[cfg(test)]
 mod tests {
-
     #[test]
     fn test_block_clone() {
         use super::{Block, BLOCK_LEN};
-        let block_a = Block::from(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+        let block_a = Block::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
         #[allow(clippy::clone_on_copy)]
         let block_b = block_a.clone();
 

--- a/aws-lc-rs/src/cipher/chacha.rs
+++ b/aws-lc-rs/src/cipher/chacha.rs
@@ -54,7 +54,7 @@ pub(crate) fn encrypt_block_chacha20(
 
     crate::fips::set_fips_service_status_unapproved();
 
-    Ok(Block::from(&cipher_text))
+    Ok(Block::from(cipher_text))
 }
 
 #[inline]

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -153,7 +153,7 @@ mod tests {
         let input_block: [u8; BLOCK_LEN] = <[u8; BLOCK_LEN]>::try_from(input).unwrap();
 
         let aes128 = SymmetricCipherKey::aes128(key.as_slice()).unwrap();
-        let result = aes128.encrypt_block(Block::from(&input_block));
+        let result = aes128.encrypt_block(Block::from(input_block));
 
         assert_eq!(expected_result.as_slice(), result.as_ref());
     }
@@ -167,7 +167,7 @@ mod tests {
         let input_block: [u8; BLOCK_LEN] = <[u8; BLOCK_LEN]>::try_from(input).unwrap();
 
         let aes128 = SymmetricCipherKey::aes256(key.as_slice()).unwrap();
-        let result = aes128.encrypt_block(Block::from(&input_block));
+        let result = aes128.encrypt_block(Block::from(input_block));
 
         assert_eq!(expected_result.as_slice(), result.as_ref());
     }


### PR DESCRIPTION
### Description of changes: 
* Avoid unnecessary copy - `Block::from` can consume its argument.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
