### PR TITLE
Safer pointer dereferences

### DIFF
--- a/aws-lc-rs/src/aead/aead_ctx.rs
+++ b/aws-lc-rs/src/aead/aead_ctx.rs
@@ -220,15 +220,15 @@ impl AeadCtx {
 
         // We are performing the allocation ourselves as EVP_AEAD_CTX_new will call EVP_AEAD_CTX_init by default
         // and this avoid having to zero and reinitalize again if we need to set an explicit direction.
-        let aead_ctx: LcPtr<EVP_AEAD_CTX> =
+        let mut aead_ctx: LcPtr<EVP_AEAD_CTX> =
             LcPtr::new(unsafe { OPENSSL_malloc(size_of::<EVP_AEAD_CTX>()) }.cast())?;
 
-        unsafe { EVP_AEAD_CTX_zero(*aead_ctx) };
+        unsafe { EVP_AEAD_CTX_zero(*aead_ctx.as_mut()) };
 
         if 1 != match direction {
             Some(direction) => unsafe {
                 EVP_AEAD_CTX_init_with_direction(
-                    *aead_ctx,
+                    *aead_ctx.as_mut(),
                     aead,
                     key_bytes.as_ptr(),
                     key_bytes.len(),
@@ -238,7 +238,7 @@ impl AeadCtx {
             },
             None => unsafe {
                 EVP_AEAD_CTX_init(
-                    *aead_ctx,
+                    *aead_ctx.as_mut(),
                     aead,
                     key_bytes.as_ptr(),
                     key_bytes.len(),

--- a/aws-lc-rs/src/bn.rs
+++ b/aws-lc-rs/src/bn.rs
@@ -19,8 +19,8 @@ impl TryFrom<u64> for LcPtr<BIGNUM> {
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         unsafe {
-            let bn = LcPtr::new(BN_new())?;
-            if 1 != BN_set_u64(*bn, value) {
+            let mut bn = LcPtr::new(BN_new())?;
+            if 1 != BN_set_u64(*bn.as_mut(), value) {
                 return Err(());
             }
             Ok(bn)

--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -214,12 +214,15 @@ impl EcdsaKeyPair {
         let digest = digest::match_digest_type(&self.algorithm.digest.id);
 
         if 1 != unsafe {
+            // EVP_DigestSignInit does not mutate |pkey| for thread-safety purposes and may be
+            // used concurrently with other non-mutating functions on |pkey|.
+            // https://github.com/aws/aws-lc/blob/9b4b5a15a97618b5b826d742419ccd54c819fa42/include/openssl/evp.h#L297-L313
             EVP_DigestSignInit(
                 md_ctx.as_mut_ptr(),
                 null_mut(),
                 *digest,
                 null_mut(),
-                *self.evp_pkey,
+                *self.evp_pkey.as_mut_unsafe(),
             )
         } {
             return Err(Unspecified);
@@ -315,12 +318,12 @@ impl AsDer<EcPrivateKeyRfc5915Der<'static>> for PrivateKey<'_> {
     fn as_der(&self) -> Result<EcPrivateKeyRfc5915Der<'static>, Unspecified> {
         unsafe {
             let mut outp = null_mut::<u8>();
-            let ec_key = ConstPointer::new(EVP_PKEY_get0_EC_KEY(*self.0.evp_pkey))?;
+            let ec_key = ConstPointer::new(EVP_PKEY_get0_EC_KEY(*self.0.evp_pkey.as_const()))?;
             let length = usize::try_from(aws_lc::i2d_ECPrivateKey(*ec_key, &mut outp))
                 .map_err(|_| Unspecified)?;
-            let outp = LcPtr::new(outp)?;
+            let mut outp = LcPtr::new(outp)?;
             Ok(EcPrivateKeyRfc5915Der::take_from_slice(
-                core::slice::from_raw_parts_mut(*outp, length),
+                core::slice::from_raw_parts_mut(*outp.as_mut(), length),
             ))
         }
     }

--- a/aws-lc-rs/src/endian.rs
+++ b/aws-lc-rs/src/endian.rs
@@ -14,8 +14,10 @@ where
     const ZERO: Self;
 }
 
+use core::mem::size_of_val;
+
 pub fn as_byte_slice<E: Encoding<T>, T>(x: &[E]) -> &[u8] {
-    unsafe { core::slice::from_raw_parts(x.as_ptr().cast::<u8>(), core::mem::size_of_val(x)) }
+    unsafe { core::slice::from_raw_parts(x.as_ptr().cast::<u8>(), size_of_val(x)) }
 }
 
 /// Work around the inability to implement `AsRef` for arrays of `Encoding`s

--- a/aws-lc-rs/src/rand.rs
+++ b/aws-lc-rs/src/rand.rs
@@ -176,7 +176,7 @@ mod tests {
         let rng = SystemRandom::new();
         rng.fill(&mut random_array).unwrap();
 
-        let (mean, variance) = mean_variance(&mut random_array.into_iter()).unwrap();
+        let (mean, variance) = mean_variance(&mut random_array.into_iter());
         assert!((106f64..150f64).contains(&mean), "Mean: {mean}");
         assert!(variance > 8f64);
         println!("Mean: {mean} Variance: {variance}");
@@ -187,7 +187,7 @@ mod tests {
         let mut random_array: [u8; 173] = [0u8; 173];
         rand::fill(&mut random_array).unwrap();
 
-        let (mean, variance) = mean_variance(&mut random_array.into_iter()).unwrap();
+        let (mean, variance) = mean_variance(&mut random_array.into_iter());
         assert!((106f64..150f64).contains(&mean), "Mean: {mean}");
         assert!(variance > 8f64);
         println!("Mean: {mean} Variance: {variance}");
@@ -198,18 +198,15 @@ mod tests {
         let rando = SystemRandom::new();
         let random_array = generate(&rando).unwrap();
         let random_array: [u8; 173] = random_array.expose();
-        let (mean, variance) = mean_variance(&mut random_array.into_iter()).unwrap();
+        let (mean, variance) = mean_variance(&mut random_array.into_iter());
         assert!((106f64..150f64).contains(&mean), "Mean: {mean}");
         assert!(variance > 8f64);
         println!("Mean: {mean} Variance: {variance}");
     }
 
-    fn mean_variance<T: Into<f64>, const N: usize>(
-        iterable: &mut IntoIter<T, N>,
-    ) -> Option<(f64, f64)> {
+    fn mean_variance<T: Into<f64>, const N: usize>(iterable: &mut IntoIter<T, N>) -> (f64, f64) {
         let iter = iterable;
         let mean: Option<T> = iter.next();
-        mean.as_ref()?;
         let mut mean = mean.unwrap().into();
         let mut var_squared = 0f64;
         let mut count = 1f64;
@@ -222,6 +219,6 @@ mod tests {
                 var_squared + ((value - prev_mean) * (value - mean) - var_squared) / count;
         }
 
-        Some((mean, var_squared.sqrt()))
+        (mean, var_squared.sqrt())
     }
 }

--- a/aws-lc-rs/src/rsa/encoding.rs
+++ b/aws-lc-rs/src/rsa/encoding.rs
@@ -90,9 +90,9 @@ pub(in crate::rsa) mod rfc8017 {
             RSA_public_key_from_bytes(public_key.as_ptr(), public_key.len())
         })?;
 
-        let pkey = LcPtr::new(unsafe { EVP_PKEY_new() })?;
+        let mut pkey = LcPtr::new(unsafe { EVP_PKEY_new() })?;
 
-        if 1 != unsafe { EVP_PKEY_assign_RSA(*pkey, *rsa) } {
+        if 1 != unsafe { EVP_PKEY_assign_RSA(*pkey.as_mut(), *rsa) } {
             return Err(KeyRejected::unspecified());
         }
 
@@ -110,9 +110,9 @@ pub(in crate::rsa) mod rfc8017 {
 
         let rsa = DetachableLcPtr::new(unsafe { RSA_parse_private_key(&mut cbs) })?;
 
-        let pkey = LcPtr::new(unsafe { EVP_PKEY_new() })?;
+        let mut pkey = LcPtr::new(unsafe { EVP_PKEY_new() })?;
 
-        if 1 != unsafe { EVP_PKEY_assign_RSA(*pkey, *rsa) } {
+        if 1 != unsafe { EVP_PKEY_assign_RSA(*pkey.as_mut(), *rsa) } {
             return Err(KeyRejected::unspecified());
         }
 
@@ -147,7 +147,7 @@ pub(in crate::rsa) mod rfc5280 {
         // key_size_bytes * 5 == key_size_bytes * (1 + 400%)
         let mut der = LcCBB::new(key_size_bytes * 5);
 
-        if 1 != unsafe { EVP_marshal_public_key(der.as_mut_ptr(), **key) } {
+        if 1 != unsafe { EVP_marshal_public_key(der.as_mut_ptr(), *key.as_const()) } {
             return Err(Unspecified);
         };
 


### PR DESCRIPTION
### Description of changes: 
* Makes acquiring a mutable or const pointer from a `ManagedPointer` explicit (instead of using Deref):
  * Adds a `MutPointer` type as an analog of `ConstPointer`.
  * On a mutable `ManagedPointer` use `as_mut` to obtain a `MutPointer`. 
  * On a shared `ManagedPointer` use `as_const` to obtain a `ConstPointer`.
  * On a shared `ManagedPointer` use `as_mut_unsafe` to obtain a `MutPointer`.

### Call-outs:
The uses of `as_mut_unsafe` are limited to calls made to the following AWS-LC functions:
* EVP_PKEY_CTX_new
* EVP_PKEY_up_ref
* EVP_DigestSignInit
* EVP_DigestVerifyInit

These function only modify `EVP_PKEY` ref-count while holding a global lock.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
