### PR TITLE
Fix for C99; Add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,31 @@ jobs:
         working-directory: ./aws-lc-rs-testing
         run: cargo test --all-targets
 
+  aws-lc-rs-c-std-test:
+    if: github.repository_owner == 'aws'
+    name: C-std test ${{ matrix.os }} - ${{ matrix.c_std }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ stable ]
+        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        c_std: [ "11", "99" ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: stable
+      - name: Run cargo test
+        working-directory: ./aws-lc-rs
+        env:
+          AWS_LC_SYS_PREBUILT_NASM: 1
+          AWS_LC_SYS_C_STD: ${{ matrix.c_std }}
+        run: cargo test --all-targets --features unstable
+
   bindgen-test:
     if: github.repository_owner == 'aws'
     name: aws-lc-rs bindgen-tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,13 @@ jobs:
         with:
           toolchain: stable
       - name: Run cargo test
+        # Windows build currently fails when forcing C11:
+        # ```
+        # C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\vcruntime_c11_stdatomic.h(36,24):
+        #   error C2061: syntax error: identifier 'atomic_bool' [D:\a\aws-lc-rs\aws-lc-rs\target\debug\build\aws-lc-sys-491cb29895f6cb6c\out\build\aws-lc\crypto\crypto_objects.vcxproj]
+        # ```
+        # https://devblogs.microsoft.com/cppblog/c11-atomics-in-visual-studio-2022-version-17-5-preview-2/
+        if: ${{ matrix.c_std != '11' || matrix.os != 'windows-latest' }}
         working-directory: ./aws-lc-rs
         env:
           AWS_LC_SYS_PREBUILT_NASM: 1

--- a/aws-lc-sys/builder/cc_builder/aarch64_apple_darwin.rs
+++ b/aws-lc-sys/builder/cc_builder/aarch64_apple_darwin.rs
@@ -165,6 +165,7 @@ pub(super) const CRYPTO_LIBRARY: Library = Library {
         "crypto/rand_extra/rand_extra.c",
         "crypto/rc4/rc4.c",
         "crypto/refcount_c11.c",
+        "crypto/refcount_lock.c",
         "crypto/rsa_extra/rsa_asn1.c",
         "crypto/rsa_extra/rsa_crypt.c",
         "crypto/rsa_extra/rsa_print.c",

--- a/aws-lc-sys/builder/cc_builder/x86_64_apple_darwin.rs
+++ b/aws-lc-sys/builder/cc_builder/x86_64_apple_darwin.rs
@@ -165,6 +165,7 @@ pub(super) const CRYPTO_LIBRARY: Library = Library {
         "crypto/rand_extra/rand_extra.c",
         "crypto/rc4/rc4.c",
         "crypto/refcount_c11.c",
+        "crypto/refcount_lock.c",
         "crypto/rsa_extra/rsa_asn1.c",
         "crypto/rsa_extra/rsa_crypt.c",
         "crypto/rsa_extra/rsa_print.c",

--- a/scripts/build/collect_build_src.sh
+++ b/scripts/build/collect_build_src.sh
@@ -202,6 +202,11 @@ if [ $? -eq 1 ]; then
   echo "Error: collect_source_files failed"
   exit 1
 fi
+
+# Both "refcount_lock.c" and "refcount_c11.c" should always be listed, even though only one may provide implementations
+SOURCE_FILES+=("crypto/refcount_lock.c")
+SOURCE_FILES+=("crypto/refcount_c11.c")
+
 PROCESSED_SRC_FILES=($(process_source_files "${SOURCE_FILES[@]}"))
 if [ $? -eq 1 ]; then
   echo "Error: process_source_files failed"


### PR DESCRIPTION
### Issue
On macos, the `collect_build_src.sh` was not identifying `refcount_lock.c` as a source file b/c our automation performs the final build using the (default) C11 standard. However, `refcount_lock.c` is still needed for C99 builds, but it was not listed.

### Description of changes: 
* Updated `collect_build_src.sh` so that it will always include both `refcount_lock.c` and `refcount_c11.c` (although only one of these will actually be useful to any specific build).
* Added CI testing for popular platforms to verify that setting `AWS_LC_SYS_C_STD` to either `99` or `11` results in a successful build.
* Update the `cc_builder` source listing so that `refcount_lock.c` is included.

### Testing:
* I ran the automated workflow and verified that the `cc_builder` source listings it produces match what's in this PR: https://github.com/aws/aws-lc-rs/actions/runs/10700676326
  * You can see the diff here: https://github.com/justsmth/aws-lc-rs/compare/testing-c-std...aws:aws-lc-rs:generate/aws-lc-sys-c99

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
