### PR TITLE
bump cc version to fix build

### DIFF
--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -57,7 +57,7 @@ prebuilt-nasm = []
 cmake = "0.1.48"
 dunce = "1.0"
 fs_extra = "1.3"
-cc = { version = "1.0.83", features = ["parallel"] }
+cc = { version = "1.0.100", features = ["parallel"] }
 
 [target.'cfg(any(all(any(target_arch="x86_64",target_arch="aarch64"),any(target_os="linux",target_os="macos",target_os="windows"),any(target_env="gnu",target_env="musl",target_env="msvc",target_env="")),all(target_arch="x86",target_os="windows",target_env="msvc"),all(target_arch="x86",target_os="linux",target_env="gnu")))'.build-dependencies]
 bindgen = { version = "0.69.2", optional = true }


### PR DESCRIPTION
### Description of changes: 

This fixes a downstream build failure:

```
   Compiling aws-lc-sys v0.21.0
error[E0308]: mismatched types
   --> /home/jbp/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.21.0/builder/cc_builder.rs:128:31
    |
128 |                   cc_build.flag(format!(
    |  _______________________________^
129 | |                     "-ffile-prefix-map={}=",
130 | |                     self.manifest_dir.display()
131 | |                 ));
    | |_________________^ expected `&str`, found `String`
    |
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0308`.
error: could not compile `aws-lc-sys` (build script) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

That is because my Cargo.lock contains 1.0.90, aws-lc-sys's Cargo.toml specifies ^1.0.83, but the build script requires a [cc change](https://github.com/rust-lang/cc-rs/commit/a1e291a4f5bb7ef7f75bb6606ad2149827721946) first introduced in 1.0.100.

(The build failure is easy to work around, with just `cargo update -p cc --precise 1.0.100`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
