### PR TITLE
Fix for older GCC < 8.1.0

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -241,6 +241,9 @@ jobs:
     if: github.repository_owner == 'aws'
     name: Resolve the dependencies to the minimum SemVer version
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crate: [ 'aws-lc-rs', 'aws-lc-sys', 'aws-lc-fips-sys' ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -253,10 +256,10 @@ jobs:
       - name: Set Rust toolchain override
         run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Setup to use minimal versions
-        working-directory: ./aws-lc-rs
+        working-directory: ./${{ matrix.crate }}
         run: cargo update -Z minimal-versions
       - name: Build with minimal versions
-        working-directory: ./aws-lc-rs
+        working-directory: ./${{ matrix.crate }}
         run: cargo --locked check
 
   copyright:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -70,6 +70,37 @@ jobs:
       - name: Cross-compilation (test release)
         run: cross test -p aws-lc-rs --release --features unstable --target ${{ matrix.target }}
 
+
+  aws-lc-rs-cross-0_2_5-test:
+    if: github.repository_owner == 'aws'
+    name: cross tests ${{ matrix.target }}
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 'stable'
+      - name: Install cross
+        run: cargo install cross --locked --version 0.2.5
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: 'stable'
+          target: ${{ matrix.target }}
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Cross-compilation (build debug)
+        run: cross build -p aws-lc-rs --features unstable --target ${{ matrix.target }}
+      - name: Cross-compilation (test release)
+        run: cross test -p aws-lc-rs --release --features unstable --target ${{ matrix.target }}
+
   aws-lc-rs-ios-aarch64:
     if: github.repository_owner == 'aws'
     name: iOS aarch64 cross-platform build

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -74,7 +74,9 @@ jobs:
   aws-lc-rs-cross-0_2_5-test:
     if: github.repository_owner == 'aws'
     name: cross tests ${{ matrix.target }}
-    runs-on: macos-13
+    runs-on: ubuntu-latest
+    env:
+      CROSS_CONFIG: './Cross.toml.x86_64-unknown-linux-gnu'
     strategy:
       fail-fast: false
       matrix:

--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -125,10 +125,16 @@ impl CcBuilder {
         match opt_level.as_str() {
             "0" | "1" | "2" => {}
             _ => {
-                cc_build.flag(format!(
-                    "-ffile-prefix-map={}=",
-                    self.manifest_dir.display()
-                ));
+                let file_prefix_map_option =
+                    format!("-ffile-prefix-map={}=", self.manifest_dir.display());
+                if let Ok(true) = cc_build.is_flag_supported(&file_prefix_map_option) {
+                    cc_build.flag(file_prefix_map_option);
+                } else {
+                    cc_build.flag_if_supported(format!(
+                        "-fdebug-prefix-map={}=",
+                        self.manifest_dir.display()
+                    ));
+                }
             }
         }
 


### PR DESCRIPTION
### Issue
Older GCC compilers do not support the `-ffile-prefix-map` option.

### Description of changes: 
Check whether `-ffile-prefix-map` is supported before use.  Fallback to using `-fdebug-prefix-map` if not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
