### PR TITLE
Revert `-ffile-prefix-map` usage w/ CMake

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -72,6 +72,8 @@ jobs:
   apidiff:
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
+    env:
+      AWS_LC_SYS_CMAKE_BUILDER: 1
     strategy:
       fail-fast: false
       matrix:

--- a/aws-lc-rs/src/agreement.rs
+++ b/aws-lc-rs/src/agreement.rs
@@ -340,7 +340,7 @@ impl PrivateKey {
     }
 
     #[cfg(test)]
-    #[allow(clippy::missing_errors_doc)]
+    #[allow(clippy::missing_errors_doc, missing_docs)]
     pub fn generate_for_test(
         alg: &'static Algorithm,
         rng: &dyn crate::rand::SecureRandom,

--- a/aws-lc-rs/src/agreement/ephemeral.rs
+++ b/aws-lc-rs/src/agreement/ephemeral.rs
@@ -41,7 +41,7 @@ impl EphemeralPrivateKey {
     }
 
     #[cfg(test)]
-    #[allow(clippy::missing_errors_doc)]
+    #[allow(clippy::missing_errors_doc, missing_docs)]
     pub fn generate_for_test(
         alg: &'static Algorithm,
         rng: &dyn SecureRandom,

--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -121,6 +121,11 @@ impl CcBuilder {
                 .define("BORINGSSL_PREFIX", prefix.as_str());
         }
 
+        let compiler = cc_build.get_compiler();
+        if target_arch() == "x86" && (compiler.is_like_clang() || compiler.is_like_gnu()) {
+            cc_build.flag_if_supported("-msse2");
+        }
+
         let opt_level = cargo_env("OPT_LEVEL");
         match opt_level.as_str() {
             "0" | "1" | "2" => {}

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -90,10 +90,12 @@ impl CmakeBuilder {
             } else {
                 cmake_cfg.define("CMAKE_BUILD_TYPE", "release");
                 if target_family() == "unix" || target_env() == "gnu" {
-                    cmake_cfg.cflag(format!(
-                        "-ffile-prefix-map={}=",
-                        self.manifest_dir.display()
-                    ));
+                    // This flag is not supported on GCC < v8.1
+                    // TODO: re-enable this
+                    // cmake_cfg.cflag(format!(
+                    //     "-ffile-prefix-map={}=",
+                    //     self.manifest_dir.display()
+                    // ));
                 }
             }
         } else {


### PR DESCRIPTION
### Problem
* Consumers using older GCC compilers (< v8.1) with the `AWS_LC_SYS_CMAKE_BUILDER=1` environment variable set experience build failures due to GCC lacking support for the `-ffile-prefix-map=` option.
* For x86 (32-bit) builds, older GCC compilers do not assume the availability of SSE2. However, SSE2 is required by AWS-LC assembly.

### Description of changes: 
* Comment out the use of `-ffile-prefix-map=` for the CMake builder until we have a better solution.
* Sets the `-msse2` compiler option on `x86` builds that use the "cc" builder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
