### PR TITLE
Update FreeBSD version to 14.1 in cross compiling workflow

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -255,7 +255,7 @@ jobs:
       - name: Prepare VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: 13.2
+          release: 14.1
           usesh: true
           copyback: false
           prepare: |

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -248,6 +248,10 @@ jobs:
     if: github.repository_owner == 'aws'
     name: aws-lc-rs freebsd test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [13.4, 14.1]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -255,7 +259,7 @@ jobs:
       - name: Prepare VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: 14.1
+          release: ${{ matrix.target }}
           usesh: true
           copyback: false
           prepare: |


### PR DESCRIPTION
The latest production release of FreeBSD is 14.1

### Issues:
Resolves #535

### Description of changes: 
Update from 13.2 to 14.1

### Testing:
Check that the cross.yaml build works for FreeBSD.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
