### PR TITLE
Filter s2n-bignum symbols with prefix p256_montjscalarmul

### DIFF
--- a/scripts/build/collect_symbols.sh
+++ b/scripts/build/collect_symbols.sh
@@ -57,7 +57,7 @@ if [[ ! -d "${AWS_LC_DIR}" ]]; then
 fi
 
 function filter_symbols() {
-  grep -E '^\w*$' | grep -v -E "^bignum_" | grep -v "curve25519_x25519" | grep -v "edwards25519_"
+  grep -E '^\w*$' | grep -v -E "^bignum_" | grep -v "curve25519_x25519" | grep -v "edwards25519_" | grep -v "p256_montjscalarmul"
 }
 
 function filter_nm_symbols() {

--- a/scripts/generate/_collect_symbols_build.sh
+++ b/scripts/generate/_collect_symbols_build.sh
@@ -20,7 +20,7 @@ function cmake_build_options() {
 }
 
 function filter_symbols() {
-  grep -v "^_\?bignum_" | grep -v "_\?curve25519_x25519" | grep -v "_\?edwards25519_"
+  grep -v "^_\?bignum_" | grep -v "_\?curve25519_x25519" | grep -v "_\?edwards25519_" | grep -v "_\?p256_montjscalarmul"
 }
 
 REPO_ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
### Description of changes: 

To land https://github.com/aws/aws-lc/pull/1877, must filter new s2n-bignum symbols that are not supposed to have external linkage. Similar to e.g. https://github.com/aws/aws-lc-rs/pull/286

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
