### PR TITLE
Update CI runners for MacOS

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -180,7 +180,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -153,6 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install build dependencies
+        # cargo-xwin apparently require ninja-build
         run: |
           sudo apt-get update && sudo apt-get install --assume-yes nasm clang ninja-build llvm
       - uses: actions/checkout@v3

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -106,7 +106,7 @@ jobs:
   aws-lc-rs-ios-aarch64:
     if: github.repository_owner == 'aws'
     name: iOS aarch64 cross-platform build
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v3
         with:
@@ -128,7 +128,7 @@ jobs:
   aws-lc-rs-ios-x86_64:
     if: github.repository_owner == 'aws'
     name: iOS x86-64 cross-platform build
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v3
         with:
@@ -251,7 +251,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [13.4, 14.1]
+        version: [ 13.4, 14.1 ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fips-bindings-generator.yml
+++ b/.github/workflows/fips-bindings-generator.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
         args:
           - --release --all-targets --features fips,unstable
           - --profile release-lto --all-targets --features fips,unstable

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
     env:
       GIT_CLONE_PROTECTION_ACTIVE: false
     steps:
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
         features: [ aws-lc-rs, aws-lc-rs-fips, aws-lc-sys, aws-lc-fips-sys ]
     steps:
       - uses: actions/checkout@v3
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ windows-latest, ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ windows-latest, ubuntu-latest, macos-13, macos-14-xlarge ]
         crate: [ aws-lc-sys, aws-lc-rs, aws-lc-fips-sys ]
         args:
           - publish --dry-run
@@ -182,25 +182,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
           lfs: true
 
-      - if: ${{ matrix.os == 'macos-13-xlarge' }}
+      - if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install llvm
           echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"'
           echo 'export LIBCLANG_PATH=/opt/homebrew/opt/llvm' >> "$GITHUB_ENV"
-
-      - if: ${{ matrix.os == 'macos-12' }}
-        run: |
-          brew install llvm
-          echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"'
-          echo 'export LIBCLANG_PATH=/usr/local/opt/llvm' >> "$GITHUB_ENV"
-
       - name: Install NASM on Windows
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -198,10 +198,6 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
 
-      - name: Install ninja-build tool
-        if: runner.os == 'Windows'
-        uses: seanmiddleditch/gha-setup-ninja@v4
-
       - name: Install MSRV Rust version
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/pregen-bindings.yml
+++ b/.github/workflows/pregen-bindings.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install OS Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y --no-install-recommends install cmake gcc clang ninja-build golang
+          sudo apt-get -y --no-install-recommends install cmake gcc clang golang
       - name: Regenerate aws-lc-sys crate
         working-directory: ./aws-lc-sys
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Install OS Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y --no-install-recommends install cmake gcc clang ninja-build golang
+          sudo apt-get -y --no-install-recommends install cmake gcc clang golang
       - name: Regenerate aws-lc-fips-sys crate
         working-directory: ./aws-lc-fips-sys
         run: |

--- a/.github/workflows/sys-bindings-generator.yml
+++ b/.github/workflows/sys-bindings-generator.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -238,7 +238,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
         args:
           - --all-targets --features unstable
           - --release --all-targets --features unstable
@@ -151,7 +151,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
         c_std: [ "11", "99" ]
         cmake: [ '0', '1' ]
     steps:
@@ -187,7 +187,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
         args:
           - --no-default-features --features aws-lc-sys,bindgen,unstable
           - --release --all-targets --features bindgen,unstable
@@ -195,16 +195,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - if: ${{ matrix.os == 'macos-13-xlarge' }}
+      - if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install llvm
           echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> "$GITHUB_ENV"
           echo 'export LIBCLANG_PATH=/opt/homebrew/opt/llvm' >> "$GITHUB_ENV"
-      - if: ${{ matrix.os == 'macos-12' }}
-        run: |
-          brew install llvm
-          echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> "$GITHUB_ENV"
-          echo 'export LIBCLANG_PATH=/usr/local/opt/llvm' >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
@@ -320,7 +315,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
         static: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v4
@@ -405,7 +400,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -433,7 +428,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
         static: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v4
@@ -458,7 +453,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -493,7 +488,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -532,7 +527,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-13-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -563,8 +558,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-12
-          - macos-13-xlarge
+          - macos-13
+          - macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
         with:
@@ -575,16 +570,11 @@ jobs:
         with:
           toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
           components: 'rust-src'
-      - if: ${{ matrix.os == 'macos-13-xlarge' }}
+      - if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install llvm
           echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"'
           echo 'export LIBCLANG_PATH=/opt/homebrew/opt/llvm' >> "$GITHUB_ENV"
-      - if: ${{ matrix.os == 'macos-12' }}
-        run: |
-          brew install llvm
-          echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"'
-          echo 'export LIBCLANG_PATH=/usr/local/opt/llvm' >> "$GITHUB_ENV"
       - name: Set Rust toolchain override
         run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Install cargo-careful

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -408,14 +408,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - if: ${{ matrix.os == 'windows-latest' }}
         uses: ilammy/setup-nasm@v1
-      - if: ${{ matrix.os == 'windows-latest' }}
-        uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Install bindgen-cli
         run: cargo install --locked bindgen-cli
       - name: Remove bindings
         run: |
-          rm ./aws-lc-fips-sys/src/x86_64* 
-          rm ./aws-lc-fips-sys/src/aarch64*
+          rm ./aws-lc-sys/src/x86_64* 
+          rm ./aws-lc-sys/src/aarch64*
       - name: Run cargo test
         run: cargo test --tests -p aws-lc-rs --no-default-features --features aws-lc-sys
 


### PR DESCRIPTION
### Description of changes: 
* Update CI to use more recent MacOS images.
   * Support for MacOS 12 ended September 16, 2024: https://en.wikipedia.org/wiki/MacOS_Monterey
* Ninja only needed for Windows/FIPS and `cargo-xwin` builds.  Not installing it unless needed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
