### PR TITLE
Fix FreeBSD build not targetting release 13.4

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -252,7 +252,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ 13.4, 14.1 ]
+        target: [ 13.4, 14.1 ]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Description of changes:

Fix typo in the cross build for FreeBSD. Only the latest release was being targeted.

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
