### PR TITLE
Use -pthread, and on more platforms

### DIFF
--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -104,8 +104,12 @@ impl CcBuilder {
         let compiler = cc_build.get_compiler();
         if compiler.is_like_gnu() || compiler.is_like_clang() {
             cc_build.flag("-Wno-unused-parameter");
-            if target_os() == "linux" || target_env() == "gnu" {
-                cc_build.define("_XOPEN_SOURCE", "700").flag("-lpthread");
+            if target_os() == "linux"
+                || target_os().ends_with("bsd")
+                || target_env() == "gnu"
+                || target_env() == "musl"
+            {
+                cc_build.define("_XOPEN_SOURCE", "700").flag("-pthread");
             }
         }
 


### PR DESCRIPTION
### Issues:
Addresses #556

### Description of changes: 
* Use the `-pthread` compiler option.
* Use it for *BSD platforms also.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
