### PR TITLE
Improve handling/logging for Android builds

### DIFF
--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -187,21 +187,7 @@ impl CmakeBuilder {
         }
 
         if target_os() == "android" {
-            cmake_cfg.define("CMAKE_SYSTEM_NAME", "Android");
-
-            let target = target();
-            let proc = target.split('-').next().unwrap();
-            match proc {
-                "armv7" => {
-                    cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "armv7-a");
-                }
-                "arm" => {
-                    cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "armv6");
-                }
-                _ => {
-                    cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", proc);
-                }
-            }
+            self.configure_android(&mut cmake_cfg);
         }
 
         if target_vendor() == "apple" && target_os().to_lowercase() == "ios" {
@@ -219,6 +205,29 @@ impl CmakeBuilder {
         }
 
         cmake_cfg
+    }
+
+    fn configure_android(&self, _cmake_cfg: &mut cmake::Config) {
+        // If we leave CMAKE_SYSTEM_PROCESSOR unset, then cmake-rs should handle properly setting
+        // CMAKE_SYSTEM_NAME and CMAKE_SYSTEM_PROCESSOR:
+        // https://github.com/rust-lang/cmake-rs/blob/b689783b5448966e810d515c798465f2e0ab56fd/src/lib.rs#L450-L499
+
+        // Log relevant environment variables.
+        if let Some(value) = option_env("ANDROID_NDK_ROOT") {
+            emit_warning(&format!("Found ANDROID_NDK_ROOT={value}"));
+        } else {
+            emit_warning("ANDROID_NDK_ROOT not set.");
+        }
+        if let Some(value) = option_env("ANDROID_NDK") {
+            emit_warning(&format!("Found ANDROID_NDK={value}"));
+        } else {
+            emit_warning("ANDROID_NDK not set.");
+        }
+        if let Some(value) = option_env("ANDROID_STANDALONE_TOOLCHAIN") {
+            emit_warning(&format!("Found ANDROID_STANDALONE_TOOLCHAIN={value}"));
+        } else {
+            emit_warning("ANDROID_STANDALONE_TOOLCHAIN not set.");
+        }
     }
 
     fn configure_windows(&self, cmake_cfg: &mut cmake::Config) {


### PR DESCRIPTION
### Issues:
Addresses #562

### Description of changes: 
Improvement to Android build:
* Defer the setting of `CMAKE_SYSTEM_NAME` and `CMAKE_SYSTEM_PROCESSOR` to cmake-rs.
* Log relevant environment variables to help with diagnosis and debugging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
