### PR TITLE
Support FIPS feature w/ old compilers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
 
   aws-lc-rs-1804-gcc:
     if: github.repository_owner == 'aws'
-    name: GCC ${{ matrix.gcc_version }} - Force CMake ${{ matrix.cmake }}
+    name: GCC ${{ matrix.gcc_version }} - CMake ${{ matrix.cmake }} - FIPS ${{ matrix.fips }}
     runs-on: ubuntu-20.04
     container:
       image: ubuntu:18.04
@@ -66,6 +66,7 @@ jobs:
       matrix:
         cmake: [ '0', '1' ]
         gcc_version: [ '4.8', '5', '6' ]
+        fips: [ '0', '1' ]
     steps:
       - run: |
           apt-get update
@@ -73,8 +74,9 @@ jobs:
           apt-get install -y cmake curl sudo
           apt-get install -y --no-install-recommends gpg-agent software-properties-common
           apt-add-repository --yes ppa:git-core/ppa
+          add-apt-repository --yes ppa:longsleep/golang-backports
           apt-get update
-          apt-get install -y build-essential git
+          apt-get install -y build-essential git golang-go
           curl -L -O -J https://github.com/PowerShell/PowerShell/releases/download/v7.2.23/powershell_7.2.23-1.deb_amd64.deb
           dpkg -i powershell_7.2.23-1.deb_amd64.deb
           apt-get install -f
@@ -95,13 +97,13 @@ jobs:
           version: ${{ matrix.gcc_version }}
           platform: x64
       - name: Run cargo test (debug)
-        run: cargo test -p aws-lc-rs --all-targets --features unstable
+        run: cargo test -p aws-lc-rs --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
       - name: Run cargo test (release)
-        run: cargo test -p aws-lc-rs --release --all-targets --features unstable
+        run: cargo test -p aws-lc-rs --release --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
 
   aws-lc-rs-2004-gcc:
     if: github.repository_owner == 'aws'
-    name: GCC ${{ matrix.gcc_version }} - Force CMake ${{ matrix.cmake }}
+    name: GCC ${{ matrix.gcc_version }} - CMake ${{ matrix.cmake }} - FIPS ${{ matrix.fips }}
     runs-on: ubuntu-20.04
     env:
       AWS_LC_SYS_CMAKE_BUILDER: ${{ matrix.cmake }}
@@ -110,6 +112,7 @@ jobs:
       matrix:
         cmake: [ '0', '1' ]
         gcc_version: [ '7', '8' ]
+        fips: [ '0', '1' ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -123,10 +126,14 @@ jobs:
         with:
           version: ${{ matrix.gcc_version }}
           platform: x64
+      - if: matrix.fips == '1'
+        uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
       - name: Run cargo test (debug)
-        run: cargo test -p aws-lc-rs --all-targets --features unstable
+        run: cargo test -p aws-lc-rs --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
       - name: Run cargo test (release)
-        run: cargo test -p aws-lc-rs --release --all-targets --features unstable
+        run: cargo test -p aws-lc-rs --release --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
       # The steps below verify that we're successfully using `-ffile-prefix-map`
       # to remove build environment paths from the resulting library.
       - if: ${{ matrix.gcc_version == '8' }}
@@ -138,7 +145,10 @@ jobs:
           else
             exit 1; # FAIL - we expected to find "runner"  (i.e., a path)
           fi
-      - if: ${{ matrix.gcc_version == '8' }}
+      # TODO: Due to the nature of the FIPS build (e.g., its dynamic generation of
+      # assembly files and its custom compilation commands within CMake), not all
+      # source paths are stripped from the resulting binary.
+      - if: ${{ matrix.gcc_version == '8' && matrix.fips == '0' }}
         name: Verify paths not found in release build
         run: |
           RELEASE_LIBCRYPTO=$(find ./target/release -name "libaws_lc_*_crypto.a")

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -63,6 +63,7 @@ bindgen = ["dep:bindgen"] # Generate the bindings on the targetted platform as a
 cmake = "0.1.48"
 dunce = "1.0"
 fs_extra = "1.3"
+cc = "1.0.100"
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = "")))'.build-dependencies]
 bindgen = { version = "0.69.2", optional = true }

--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -160,15 +160,17 @@ impl CcBuilder {
                     "AWS_LC_SYS_NO_ASM only allowed for debug builds!"
                 );
                 if compiler.is_like_gnu() || compiler.is_like_clang() {
-                    let file_prefix_map_option =
-                        format!("-ffile-prefix-map={}=", self.manifest_dir.display());
-                    if let Ok(true) = cc_build.is_flag_supported(&file_prefix_map_option) {
-                        cc_build.flag(file_prefix_map_option);
+                    let flag = format!("-ffile-prefix-map={}=", self.manifest_dir.display());
+                    if let Ok(true) = cc_build.is_flag_supported(&flag) {
+                        emit_warning(&format!("Using flag: {}", &flag));
+                        cc_build.flag(flag);
                     } else {
-                        cc_build.flag_if_supported(format!(
-                            "-fdebug-prefix-map={}=",
-                            self.manifest_dir.display()
-                        ));
+                        emit_warning("NOTICE: Build environment source paths might be visible in release binary.");
+                        let flag = format!("-fdebug-prefix-map={}=", self.manifest_dir.display());
+                        if let Ok(true) = cc_build.is_flag_supported(&flag) {
+                            emit_warning(&format!("Using flag: {}", &flag));
+                            cc_build.flag(flag);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description of changes: 
* The use of `-ffile-prefix-map` within the aws-lc-fips-sys build scripts was causing build failures with older compilers. This change conditions the use of the flag on the detection of compiler support.


### Call-outs:
* For the FIPS build most, but not all, of the build environment source paths are being removed. Changes to the AWS-LC CMake scripts are likely needed to fully support this.

### Testing:
* Added a CI dimension to test older compilers with FIPS feature enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
