### PR TITLE
Implement TryInto<PublicEncryptingKey> for PublicKeyComponents

### DIFF
--- a/aws-lc-rs/src/rsa/encryption.rs
+++ b/aws-lc-rs/src/rsa/encryption.rs
@@ -146,7 +146,7 @@ impl Clone for PrivateDecryptingKey {
 pub struct PublicEncryptingKey(LcPtr<EVP_PKEY>);
 
 impl PublicEncryptingKey {
-    fn new(evp_pkey: LcPtr<EVP_PKEY>) -> Result<Self, Unspecified> {
+    pub(crate) fn new(evp_pkey: LcPtr<EVP_PKEY>) -> Result<Self, Unspecified> {
         Self::validate_key(&evp_pkey)?;
         Ok(Self(evp_pkey))
     }

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -14,13 +14,13 @@ use crate::io;
 use crate::ptr::ConstPointer;
 use crate::{
     digest::{self},
-    rsa::{PublicEncryptingKey},
     encoding::{AsDer, Pkcs8V1Der},
     error::{KeyRejected, Unspecified},
     fips::indicator_check,
     hex,
     ptr::{DetachableLcPtr, LcPtr},
     rand,
+    rsa::{PublicEncryptingKey},
     sealed::Sealed,
 };
 #[cfg(feature = "fips")]

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -14,6 +14,7 @@ use crate::io;
 use crate::ptr::ConstPointer;
 use crate::{
     digest::{self},
+    rsa::{PublicEncryptingKey},
     encoding::{AsDer, Pkcs8V1Der},
     error::{KeyRejected, Unspecified},
     fips::indicator_check,
@@ -429,6 +430,16 @@ where
         rsa.detach();
 
         Ok(pkey)
+    }
+
+    /// Builds a `PublicEncryptingKey` from the public key components.
+    ///
+    /// # Errors
+    /// `error::Unspecified` if the key failed to verify.
+    pub fn build_encrypting_key(&self) -> Result<PublicEncryptingKey, Unspecified> {
+        let rsa = self.build_rsa()?;
+
+        PublicEncryptingKey::new(rsa)
     }
 
     /// Verifies that `signature` is a valid signature of `message` using `self`

--- a/aws-lc-rs/tests/basic_rsa_test.rs
+++ b/aws-lc-rs/tests/basic_rsa_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use aws_lc_rs::rand::SystemRandom;
-use aws_lc_rs::rsa::Pkcs1PublicEncryptingKey;
+use aws_lc_rs::rsa::{Pkcs1PublicEncryptingKey, PublicEncryptingKey};
 use aws_lc_rs::signature;
 use aws_lc_rs::signature::RsaKeyPair;
 use aws_lc_rs::test::from_dirty_hex;
@@ -210,14 +210,11 @@ fn test_encryption_rsa_primitive() {
     let msg = from_dirty_hex(r"68656c6c6f2c20776f726c64");
 
     let public_key = signature::RsaPublicKeyComponents { n: &n, e: &e };
-    let public_encrypting_key = public_key.build_encrypting_key()
-        .unwrap();
-    let pkcs_encrypting_key = Pkcs1PublicEncryptingKey::new(public_encrypting_key)
-        .unwrap();
+    let public_encrypting_key: PublicEncryptingKey = public_key.try_into().unwrap();
+    let pkcs_encrypting_key = Pkcs1PublicEncryptingKey::new(public_encrypting_key).unwrap();
 
     let mut encrypted = vec![0u8; pkcs_encrypting_key.ciphertext_size()];
-    pkcs_encrypting_key.encrypt(&msg, &mut encrypted)
-        .unwrap();
+    pkcs_encrypting_key.encrypt(&msg, &mut encrypted).unwrap();
 
     assert_ne!(encrypted, msg);
 }


### PR DESCRIPTION
### Issues:
Resolves #581 

### Description of changes: 
Adds `impl TryInto<PublicEncryptingKey> for PublicKeyComponents`.

### Call-outs:
N/A

### Testing:
Im not sure how to implement unit tests for this change would need a reviewer to assist with this. I tested them in my personal application and they functioned as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
