### PR TITLE
Disable `-Woverriding-t-option`

### DIFF
--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -187,6 +187,7 @@ impl CmakeBuilder {
         // If the build environment vendor is Apple
         #[cfg(target_vendor = "apple")]
         {
+            cmake_cfg.cflag("-Wno-overriding-t-option");
             if target_arch() == "aarch64" {
                 cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "arm64");
                 cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "arm64");

--- a/aws-lc-rs/src/aead/tests/fips.rs
+++ b/aws-lc-rs/src/aead/tests/fips.rs
@@ -28,7 +28,7 @@ const TEST_NONCE_96_BIT: [u8; 12] = [
     0xe4, 0x39, 0x17, 0x95, 0x86, 0xcd, 0xcd, 0x5a, 0x1b, 0x46, 0x7b, 0x1d,
 ];
 
-const TEST_MESSAGE: &str = "test message";
+const TEST_MESSAGE: &[u8] = "test message".as_bytes();
 
 macro_rules! nonce_sequence_api {
     ($name:ident, $alg:expr, $key:expr, $seal_expect:path, $open_expect:path) => {
@@ -59,7 +59,7 @@ macro_rules! nonce_sequence_api {
                 )
                 .unwrap();
 
-                assert_eq!(TEST_MESSAGE.as_bytes(), result);
+                assert_eq!(TEST_MESSAGE, result);
             }
 
             {
@@ -89,7 +89,7 @@ macro_rules! nonce_sequence_api {
                 )
                 .unwrap();
 
-                assert_eq!(TEST_MESSAGE.as_bytes(), result);
+                assert_eq!(TEST_MESSAGE, result);
             }
         }
     };
@@ -137,7 +137,7 @@ macro_rules! randnonce_api {
                 )
                 .unwrap();
 
-                assert_eq!(TEST_MESSAGE.as_bytes(), in_out);
+                assert_eq!(TEST_MESSAGE, in_out);
             }
 
             {
@@ -157,7 +157,7 @@ macro_rules! randnonce_api {
                 )
                 .unwrap();
 
-                assert_eq!(TEST_MESSAGE.as_bytes(), in_out);
+                assert_eq!(TEST_MESSAGE, in_out);
             }
         }
     };
@@ -213,7 +213,7 @@ macro_rules! tls_nonce_api {
             )
             .unwrap();
 
-            assert_eq!(in_out, TEST_MESSAGE.as_bytes());
+            assert_eq!(in_out, TEST_MESSAGE);
         }
     };
     // Match for unsupported variants

--- a/aws-lc-rs/src/aead/tests/fips/chacha20_poly1305_openssh.rs
+++ b/aws-lc-rs/src/aead/tests/fips/chacha20_poly1305_openssh.rs
@@ -17,7 +17,7 @@ fn test() {
 
     #[allow(clippy::cast_possible_truncation)]
     message.extend_from_slice({
-        let len = TEST_MESSAGE.as_bytes().len() as u32;
+        let len = TEST_MESSAGE.len() as u32;
         &[
             ((len & 0xFF00_0000) >> 24) as u8,
             ((len & 0xFF_0000) >> 16) as u8,
@@ -25,7 +25,7 @@ fn test() {
             (len & 0xFF) as u8,
         ]
     });
-    message.extend_from_slice(TEST_MESSAGE.as_bytes());
+    message.extend_from_slice(TEST_MESSAGE);
 
     let mut tag = [0u8; 16];
 
@@ -58,5 +58,5 @@ fn test() {
         key.open_in_place(1024, &mut message, &tag).unwrap(),
         FipsServiceStatus::NonApproved
     );
-    assert_eq!(TEST_MESSAGE.as_bytes(), message);
+    assert_eq!(TEST_MESSAGE, message);
 }

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -562,7 +562,7 @@ mod tests {
         let public_key = key_pair.public_key();
         let signature = key_pair.sign(MESSAGE);
         let unparsed_public_key = UnparsedPublicKey::new(&ED25519, public_key.as_ref());
-        let _ = unparsed_public_key
+        unparsed_public_key
             .verify(MESSAGE, signature.as_ref())
             .unwrap();
     }

--- a/aws-lc-rs/src/test.rs
+++ b/aws-lc-rs/src/test.rs
@@ -201,9 +201,9 @@ impl TestCase {
         let s = self.consume_optional_string(key)?;
         let result = if s.starts_with('\"') {
             // The value is a quoted UTF-8 string.
-
+            let s = s.as_bytes();
             let mut bytes = Vec::with_capacity(s.len());
-            let mut s = s.as_bytes().iter().skip(1);
+            let mut s = s.iter().skip(1);
             loop {
                 let b = match s.next() {
                     Some(b'\\') => {


### PR DESCRIPTION
### Context
* Our MacOS (x86-64) builds for `aws-lc-sys-fips` have started failing recently. For example: https://github.com/aws/aws-lc-rs/actions/runs/11675784224/job/32547525030#step:9:1
```
  clang: error: overriding '-mmacosx-version-min=13.7' option with '--target=x86_64-apple-macosx14.2' [-Werror,-Woverriding-t-option]
```
* This issue only affects our FIPS build due to [platform-specific CMake logic](https://github.com/aws/aws-lc/blob/49215e8da6bed791655fbbbd8c6b8850c8e687a2/crypto/fipsmodule/CMakeLists.txt#L498) that adds the `-mmacosx-version-min=` compiler flag on FIPS builds. 


### Description of changes: 
* This change adds the `-Wno-overriding-t-option` compiler flag when building `aws-lc-sys-fips` to avoid this failure.

### Call-outs:
* Fixed several new Clippy findings affecting test logic.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
