### PR TITLE
Also aws-lc-sys -Wno-overriding-t-option

### DIFF
--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -176,6 +176,7 @@ impl CmakeBuilder {
         // If the build environment vendor is Apple
         #[cfg(target_vendor = "apple")]
         {
+            cmake_cfg.cflag("-Wno-overriding-t-option");
             if target_arch() == "aarch64" {
                 cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "arm64");
                 cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "arm64");


### PR DESCRIPTION
### Description of changes:
I found that [this error](https://github.com/aws/aws-lc-rs/actions/runs/11862568768/job/33062282018?pr=588#step:4:250) can also happen in aws-lc-sys:
```
error: failed to run custom build command for `aws-lc-sys v0.23.0 (/Users/runner/work/aws-lc-rs/aws-lc-rs/aws-lc-sys)`
...
clang: error: overriding '-mmacosx-version-min=13.7' option with '--target=x86_64-apple-macosx14.2' [-Werror,-Woverriding-t-option]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
