### PR TITLE
AES ECB mode support

### DIFF
--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -7,7 +7,7 @@
 //!
 //! See draft-ietf-quic-tls.
 
-use crate::cipher::aes::encrypt_block_aes;
+use crate::cipher::aes::encrypt_block;
 use crate::cipher::block;
 use crate::cipher::chacha::encrypt_block_chacha20;
 use crate::cipher::key::SymmetricCipherKey;
@@ -149,7 +149,7 @@ fn cipher_new_mask(
 
     let encrypted_block = match cipher_key {
         SymmetricCipherKey::Aes128 { enc_key, .. } | SymmetricCipherKey::Aes256 { enc_key, .. } => {
-            encrypt_block_aes(enc_key, block)
+            encrypt_block(enc_key, block)
         }
         SymmetricCipherKey::ChaCha20 { raw_key } => {
             let plaintext = block.as_ref();

--- a/aws-lc-rs/src/cipher/aes.rs
+++ b/aws-lc-rs/src/cipher/aes.rs
@@ -3,12 +3,14 @@
 // Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use crate::{
-    cipher::block::{Block, BLOCK_LEN},
-    fips::indicator_check,
+use crate::{cipher::block::Block, error::Unspecified, fips::indicator_check};
+use aws_lc::{
+    AES_cbc_encrypt, AES_cfb128_encrypt, AES_ctr128_encrypt, AES_ecb_encrypt, AES_DECRYPT,
+    AES_ENCRYPT, AES_KEY,
 };
-use aws_lc::{AES_ecb_encrypt, AES_ENCRYPT, AES_KEY};
-use core::mem::MaybeUninit;
+use zeroize::Zeroize;
+
+use super::{DecryptionContext, EncryptionContext, OperatingMode, SymmetricCipherKey};
 
 /// Length of an AES-128 key in bytes.
 pub const AES_128_KEY_LEN: usize = 16;
@@ -16,19 +18,327 @@ pub const AES_128_KEY_LEN: usize = 16;
 /// Length of an AES-256 key in bytes.
 pub const AES_256_KEY_LEN: usize = 32;
 
+/// The number of bytes for an AES-CBC initialization vector (IV)
+pub const AES_CBC_IV_LEN: usize = 16;
+
+/// The number of bytes for an AES-CTR initialization vector (IV)
+pub const AES_CTR_IV_LEN: usize = 16;
+
+/// The number of bytes for an AES-CFB initialization vector (IV)
+pub const AES_CFB_IV_LEN: usize = 16;
+
+pub const AES_BLOCK_LEN: usize = 16;
+
 #[inline]
-pub(crate) fn encrypt_block_aes(aes_key: &AES_KEY, block: Block) -> Block {
-    unsafe {
-        let mut cipher_text = MaybeUninit::<[u8; BLOCK_LEN]>::uninit();
-        let plain_bytes = block.as_ref();
-
-        indicator_check!(AES_ecb_encrypt(
-            plain_bytes.as_ptr(),
-            cipher_text.as_mut_ptr().cast(),
-            aes_key,
-            AES_ENCRYPT,
-        ));
-
-        Block::from(cipher_text.assume_init())
+pub(crate) fn encrypt_block(aes_key: &AES_KEY, mut block: Block) -> Block {
+    {
+        let block_ref = block.as_mut();
+        assert!(block_ref.len() == AES_BLOCK_LEN);
+        aes_ecb_encrypt(aes_key, block_ref);
     }
+    block
+}
+
+pub(super) fn encrypt_ctr_mode(
+    key: &SymmetricCipherKey,
+    context: EncryptionContext,
+    in_out: &mut [u8],
+) -> Result<DecryptionContext, Unspecified> {
+    #[allow(clippy::match_wildcard_for_single_variants)]
+    let key = match &key {
+        SymmetricCipherKey::Aes128 { enc_key, .. } | SymmetricCipherKey::Aes256 { enc_key, .. } => {
+            enc_key
+        }
+        _ => unreachable!(),
+    };
+
+    let mut iv = {
+        let mut iv = [0u8; AES_CTR_IV_LEN];
+        iv.copy_from_slice((&context).try_into()?);
+        iv
+    };
+
+    let mut buffer = [0u8; AES_BLOCK_LEN];
+
+    aes_ctr128_encrypt(key, &mut iv, &mut buffer, in_out);
+    iv.zeroize();
+
+    Ok(context.into())
+}
+
+pub(super) fn decrypt_ctr_mode<'in_out>(
+    key: &SymmetricCipherKey,
+    context: DecryptionContext,
+    in_out: &'in_out mut [u8],
+) -> Result<&'in_out mut [u8], Unspecified> {
+    // it's the same in CTR, just providing a nice named wrapper to match
+    encrypt_ctr_mode(key, context.into(), in_out).map(|_| in_out)
+}
+
+pub(super) fn encrypt_cbc_mode(
+    key: &SymmetricCipherKey,
+    context: EncryptionContext,
+    in_out: &mut [u8],
+) -> Result<DecryptionContext, Unspecified> {
+    #[allow(clippy::match_wildcard_for_single_variants)]
+    let key = match &key {
+        SymmetricCipherKey::Aes128 { enc_key, .. } | SymmetricCipherKey::Aes256 { enc_key, .. } => {
+            enc_key
+        }
+        _ => unreachable!(),
+    };
+
+    let mut iv = {
+        let mut iv = [0u8; AES_CBC_IV_LEN];
+        iv.copy_from_slice((&context).try_into()?);
+        iv
+    };
+
+    aes_cbc_encrypt(key, &mut iv, in_out);
+    iv.zeroize();
+
+    Ok(context.into())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn decrypt_cbc_mode<'in_out>(
+    key: &SymmetricCipherKey,
+    context: DecryptionContext,
+    in_out: &'in_out mut [u8],
+) -> Result<&'in_out mut [u8], Unspecified> {
+    #[allow(clippy::match_wildcard_for_single_variants)]
+    let key = match &key {
+        SymmetricCipherKey::Aes128 { dec_key, .. } | SymmetricCipherKey::Aes256 { dec_key, .. } => {
+            dec_key
+        }
+        _ => unreachable!(),
+    };
+
+    let mut iv = {
+        let mut iv = [0u8; AES_CBC_IV_LEN];
+        iv.copy_from_slice((&context).try_into()?);
+        iv
+    };
+
+    aes_cbc_decrypt(key, &mut iv, in_out);
+    iv.zeroize();
+
+    Ok(in_out)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn encrypt_cfb_mode(
+    key: &SymmetricCipherKey,
+    mode: OperatingMode,
+    context: EncryptionContext,
+    in_out: &mut [u8],
+) -> Result<DecryptionContext, Unspecified> {
+    #[allow(clippy::match_wildcard_for_single_variants)]
+    let key = match &key {
+        SymmetricCipherKey::Aes128 { enc_key, .. } | SymmetricCipherKey::Aes256 { enc_key, .. } => {
+            enc_key
+        }
+        _ => unreachable!(),
+    };
+
+    let mut iv = {
+        let mut iv = [0u8; AES_CFB_IV_LEN];
+        iv.copy_from_slice((&context).try_into()?);
+        iv
+    };
+
+    let cfb_encrypt: fn(&AES_KEY, &mut [u8], &mut [u8]) = match mode {
+        // TODO: Hopefully support CFB1, and CFB8
+        OperatingMode::CFB128 => aes_cfb128_encrypt,
+        _ => unreachable!(),
+    };
+
+    cfb_encrypt(key, &mut iv, in_out);
+    iv.zeroize();
+
+    Ok(context.into())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(super) fn decrypt_cfb_mode<'in_out>(
+    key: &SymmetricCipherKey,
+    mode: OperatingMode,
+    context: DecryptionContext,
+    in_out: &'in_out mut [u8],
+) -> Result<&'in_out mut [u8], Unspecified> {
+    #[allow(clippy::match_wildcard_for_single_variants)]
+    let key = match &key {
+        SymmetricCipherKey::Aes128 { enc_key, .. } | SymmetricCipherKey::Aes256 { enc_key, .. } => {
+            enc_key
+        }
+        _ => unreachable!(),
+    };
+
+    let mut iv = {
+        let mut iv = [0u8; AES_CFB_IV_LEN];
+        iv.copy_from_slice((&context).try_into()?);
+        iv
+    };
+
+    let cfb_decrypt: fn(&AES_KEY, &mut [u8], &mut [u8]) = match mode {
+        // TODO: Hopefully support CFB1, and CFB8
+        OperatingMode::CFB128 => aes_cfb128_decrypt,
+        _ => unreachable!(),
+    };
+
+    cfb_decrypt(key, &mut iv, in_out);
+
+    iv.zeroize();
+
+    Ok(in_out)
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::unnecessary_wraps)]
+pub(super) fn encrypt_ecb_mode(
+    key: &SymmetricCipherKey,
+    context: EncryptionContext,
+    in_out: &mut [u8],
+) -> Result<DecryptionContext, Unspecified> {
+    if !matches!(context, EncryptionContext::None) {
+        unreachable!();
+    }
+
+    #[allow(clippy::match_wildcard_for_single_variants)]
+    let key = match &key {
+        SymmetricCipherKey::Aes128 { enc_key, .. } | SymmetricCipherKey::Aes256 { enc_key, .. } => {
+            enc_key
+        }
+        _ => unreachable!(),
+    };
+
+    let mut in_out_iter = in_out.chunks_exact_mut(AES_BLOCK_LEN);
+
+    for block in in_out_iter.by_ref() {
+        aes_ecb_encrypt(key, block);
+    }
+
+    // This is a sanity check that should not happen. We validate in `encrypt` that in_out.len() % block_len == 0
+    // for this mode.
+    assert!(in_out_iter.into_remainder().is_empty());
+
+    Ok(context.into())
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::unnecessary_wraps)]
+pub(super) fn decrypt_ecb_mode<'in_out>(
+    key: &SymmetricCipherKey,
+    context: DecryptionContext,
+    in_out: &'in_out mut [u8],
+) -> Result<&'in_out mut [u8], Unspecified> {
+    if !matches!(context, DecryptionContext::None) {
+        unreachable!();
+    }
+
+    #[allow(clippy::match_wildcard_for_single_variants)]
+    let key = match &key {
+        SymmetricCipherKey::Aes128 { dec_key, .. } | SymmetricCipherKey::Aes256 { dec_key, .. } => {
+            dec_key
+        }
+        _ => unreachable!(),
+    };
+
+    {
+        let mut in_out_iter = in_out.chunks_exact_mut(AES_BLOCK_LEN);
+
+        for block in in_out_iter.by_ref() {
+            aes_ecb_decrypt(key, block);
+        }
+
+        // This is a sanity check hat should not fail. We validate in `decrypt` that in_out.len() % block_len == 0 for
+        // this mode.
+        assert!(in_out_iter.into_remainder().is_empty());
+    }
+
+    Ok(in_out)
+}
+
+fn aes_ecb_encrypt(key: &AES_KEY, in_out: &mut [u8]) {
+    indicator_check!(unsafe {
+        AES_ecb_encrypt(in_out.as_ptr(), in_out.as_mut_ptr(), key, AES_ENCRYPT);
+    });
+}
+
+fn aes_ecb_decrypt(key: &AES_KEY, in_out: &mut [u8]) {
+    indicator_check!(unsafe {
+        AES_ecb_encrypt(in_out.as_ptr(), in_out.as_mut_ptr(), key, AES_DECRYPT);
+    });
+}
+
+fn aes_ctr128_encrypt(key: &AES_KEY, iv: &mut [u8], block_buffer: &mut [u8], in_out: &mut [u8]) {
+    let mut num: u32 = 0;
+
+    indicator_check!(unsafe {
+        AES_ctr128_encrypt(
+            in_out.as_ptr(),
+            in_out.as_mut_ptr(),
+            in_out.len(),
+            key,
+            iv.as_mut_ptr(),
+            block_buffer.as_mut_ptr(),
+            &mut num,
+        );
+    });
+
+    Zeroize::zeroize(block_buffer);
+}
+
+fn aes_cbc_encrypt(key: &AES_KEY, iv: &mut [u8], in_out: &mut [u8]) {
+    indicator_check!(unsafe {
+        AES_cbc_encrypt(
+            in_out.as_ptr(),
+            in_out.as_mut_ptr(),
+            in_out.len(),
+            key,
+            iv.as_mut_ptr(),
+            AES_ENCRYPT,
+        );
+    });
+}
+
+fn aes_cbc_decrypt(key: &AES_KEY, iv: &mut [u8], in_out: &mut [u8]) {
+    indicator_check!(unsafe {
+        AES_cbc_encrypt(
+            in_out.as_ptr(),
+            in_out.as_mut_ptr(),
+            in_out.len(),
+            key,
+            iv.as_mut_ptr(),
+            AES_DECRYPT,
+        );
+    });
+}
+
+fn aes_cfb128_encrypt(key: &AES_KEY, iv: &mut [u8], in_out: &mut [u8]) {
+    let mut num: i32 = 0;
+    indicator_check!(unsafe {
+        AES_cfb128_encrypt(
+            in_out.as_ptr(),
+            in_out.as_mut_ptr(),
+            in_out.len(),
+            key,
+            iv.as_mut_ptr(),
+            &mut num,
+            AES_ENCRYPT,
+        );
+    });
+}
+
+fn aes_cfb128_decrypt(key: &AES_KEY, iv: &mut [u8], in_out: &mut [u8]) {
+    let mut num: i32 = 0;
+    indicator_check!(unsafe {
+        AES_cfb128_encrypt(
+            in_out.as_ptr(),
+            in_out.as_mut_ptr(),
+            in_out.len(),
+            key,
+            iv.as_mut_ptr(),
+            &mut num,
+            AES_DECRYPT,
+        );
+    });
 }

--- a/aws-lc-rs/src/cipher/aes.rs
+++ b/aws-lc-rs/src/cipher/aes.rs
@@ -33,7 +33,7 @@ pub const AES_BLOCK_LEN: usize = 16;
 pub(crate) fn encrypt_block(aes_key: &AES_KEY, mut block: Block) -> Block {
     {
         let block_ref = block.as_mut();
-        assert!(block_ref.len() == AES_BLOCK_LEN);
+        debug_assert_eq!(block_ref.len(), AES_BLOCK_LEN);
         aes_ecb_encrypt(aes_key, block_ref);
     }
     block
@@ -219,7 +219,7 @@ pub(super) fn encrypt_ecb_mode(
 
     // This is a sanity check that should not happen. We validate in `encrypt` that in_out.len() % block_len == 0
     // for this mode.
-    assert!(in_out_iter.into_remainder().is_empty());
+    debug_assert!(in_out_iter.into_remainder().is_empty());
 
     Ok(context.into())
 }
@@ -251,7 +251,7 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
 
         // This is a sanity check hat should not fail. We validate in `decrypt` that in_out.len() % block_len == 0 for
         // this mode.
-        assert!(in_out_iter.into_remainder().is_empty());
+        debug_assert!(in_out_iter.into_remainder().is_empty());
     }
 
     Ok(in_out)

--- a/aws-lc-rs/src/cipher/block.rs
+++ b/aws-lc-rs/src/cipher/block.rs
@@ -38,6 +38,14 @@ impl AsRef<[u8; BLOCK_LEN]> for Block {
     }
 }
 
+impl AsMut<[u8; BLOCK_LEN]> for Block {
+    #[allow(clippy::transmute_ptr_to_ptr)]
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8; BLOCK_LEN] {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -49,6 +57,18 @@ mod tests {
 
         for i in 0..BLOCK_LEN {
             assert_eq!(block_a.as_ref()[i], block_b.as_ref()[i]);
+        }
+    }
+
+    #[test]
+    fn test_block_clone_mut_ref() {
+        use super::{Block, BLOCK_LEN};
+        let mut block_a = Block::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+        #[allow(clippy::clone_on_copy)]
+        let mut block_b = block_a.clone();
+
+        for i in 0..BLOCK_LEN {
+            assert_eq!(block_a.as_mut()[i], block_b.as_mut()[i]);
         }
     }
 }

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use crate::cipher::aes::encrypt_block_aes;
 use crate::cipher::block::Block;
 use crate::cipher::chacha::ChaCha20Key;
 use crate::cipher::{AES_128_KEY_LEN, AES_256_KEY_LEN};
@@ -133,7 +132,9 @@ impl SymmetricCipherKey {
     pub(crate) fn encrypt_block(&self, block: Block) -> Block {
         match self {
             SymmetricCipherKey::Aes128 { enc_key, .. }
-            | SymmetricCipherKey::Aes256 { enc_key, .. } => encrypt_block_aes(enc_key, block),
+            | SymmetricCipherKey::Aes256 { enc_key, .. } => {
+                super::aes::encrypt_block(enc_key, block)
+            }
             SymmetricCipherKey::ChaCha20 { .. } => panic!("Unsupported algorithm!"),
         }
     }

--- a/aws-lc-rs/src/cipher/padded.rs
+++ b/aws-lc-rs/src/cipher/padded.rs
@@ -91,6 +91,10 @@ impl PaddedBlockEncryptingKey {
 
     /// Constructs a new `PaddedBlockEncryptingKey` cipher with electronic code book (ECB) mode.
     /// Plaintext data is padded following the PKCS#7 scheme.
+    /// 
+    /// # ☠️ ️️️DANGER ☠️
+    /// Offered for computability purposes only. This is an extremely dangerous mode, and
+    /// very likely not what you want to use.
     ///
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing a `PaddedBlockEncryptingKey`.
@@ -206,6 +210,10 @@ impl PaddedBlockDecryptingKey {
 
     /// Constructs a new `PaddedBlockDecryptingKey` cipher with electronic code book (ECB) mode.
     /// Decrypted data is unpadded following the PKCS#7 scheme.
+    /// 
+    /// # ☠️ ️️️DANGER ☠️
+    /// Offered for computability purposes only. This is an extremely dangerous mode, and
+    /// very likely not what you want to use.
     ///
     // # FIPS
     // Use this function with an `UnboundCipherKey` constructed with one of the following algorithms:

--- a/aws-lc-rs/src/cipher/padded.rs
+++ b/aws-lc-rs/src/cipher/padded.rs
@@ -85,8 +85,17 @@ impl PaddedBlockEncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing a `PaddedBlockEncryptingKey`.
-    pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<PaddedBlockEncryptingKey, Unspecified> {
-        PaddedBlockEncryptingKey::new(key, OperatingMode::CBC, PaddingStrategy::PKCS7)
+    pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
+        Self::new(key, OperatingMode::CBC, PaddingStrategy::PKCS7)
+    }
+
+    /// Constructs a new `PaddedBlockEncryptingKey` cipher with electronic code book (ECB) mode.
+    /// Plaintext data is padded following the PKCS#7 scheme.
+    ///
+    /// # Errors
+    /// * [`Unspecified`]: Returned if there is an error constructing a `PaddedBlockEncryptingKey`.
+    pub fn ecb_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
+        Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }
 
     #[allow(clippy::unnecessary_wraps)]
@@ -97,7 +106,7 @@ impl PaddedBlockEncryptingKey {
     ) -> Result<PaddedBlockEncryptingKey, Unspecified> {
         let algorithm = key.algorithm();
         let key = key.try_into()?;
-        Ok(PaddedBlockEncryptingKey {
+        Ok(Self {
             algorithm,
             key,
             mode,
@@ -191,8 +200,22 @@ impl PaddedBlockDecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
-    pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<PaddedBlockDecryptingKey, Unspecified> {
-        PaddedBlockDecryptingKey::new(key, OperatingMode::CBC, PaddingStrategy::PKCS7)
+    pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
+        Self::new(key, OperatingMode::CBC, PaddingStrategy::PKCS7)
+    }
+
+    /// Constructs a new `PaddedBlockDecryptingKey` cipher with electronic code book (ECB) mode.
+    /// Decrypted data is unpadded following the PKCS#7 scheme.
+    ///
+    // # FIPS
+    // Use this function with an `UnboundCipherKey` constructed with one of the following algorithms:
+    // * `AES_128`
+    // * `AES_256`
+    //
+    /// # Errors
+    /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
+    pub fn ecb_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
+        Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }
 
     #[allow(clippy::unnecessary_wraps)]


### PR DESCRIPTION
### Issues:
Resolves #573

### Description of changes: 
* Adds support for ECB mode with pkcs7 padding
* Adds support for ECB mode with pkcs7 padding using the streaming interface
* Adds support for ECB mode without padding (requires input/output to be multiple of block length).

### Call-outs:
* Streaming mode doesn't support ECB without padding as the EVP interface doesn't have a way to toggle off the behavior for this mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
