### PR TITLE
Set GOCACHE under OUT_DIR

### DIFF
--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -91,6 +91,8 @@ impl CmakeBuilder {
 
     #[allow(clippy::too_many_lines)]
     fn prepare_cmake_build(&self) -> cmake::Config {
+        env::set_var("GOCACHE", self.out_dir.join("go-build").as_os_str());
+
         let mut cmake_cfg = self.get_cmake_config();
 
         if OutputLibType::default() == OutputLibType::Dynamic {

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -89,9 +89,13 @@ impl CmakeBuilder {
         cmake::Config::new(&self.manifest_dir)
     }
 
+    const GOCACHE_DIR_NAME: &'static str = "go-cache";
     #[allow(clippy::too_many_lines)]
     fn prepare_cmake_build(&self) -> cmake::Config {
-        env::set_var("GOCACHE", self.out_dir.join("go-build").as_os_str());
+        env::set_var(
+            "GOCACHE",
+            self.out_dir.join(Self::GOCACHE_DIR_NAME).as_os_str(),
+        );
 
         let mut cmake_cfg = self.get_cmake_config();
 


### PR DESCRIPTION
### Issues
Addresses:
* #600

### Context
* The documentation build for [aws-lc-fips-sys on docs.rs](https://docs.rs/crate/aws-lc-fips-sys) is failing.  The build log indicates that it's due to the Go compiler being unable to initialize its cache directory: https://docs.rs/crate/aws-lc-fips-sys/0.12.14/builds/1543179
```
...
[INFO] [stderr]   --- stderr
[INFO] [stderr]   failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
...
```
  * The [`GOCACHE` environment variable](https://pkg.go.dev/cmd/go#hdr-Environment_variables) determines the location for this directory.

### Description of changes: 
* Sets the GOCACHE environment variable to be beneath ${OUT_DIR}, in which the Go compiler should have permission to create its `.cache` directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
