### PR TITLE
Fix for aarch64-apple-ios

### DIFF
--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -188,6 +188,14 @@ impl CcBuilder {
             env::set_var("CFLAGS", cflags);
         }
 
+        if target_os() == "macos" && target_arch() == "x86_64" {
+            // This compiler error has only been seen on MacOS x86_64:
+            // ```
+            // clang: error: overriding '-mmacosx-version-min=13.7' option with '--target=x86_64-apple-macosx14.2' [-Werror,-Woverriding-t-option]
+            // ```
+            cc_build.flag_if_supported("-Wno-overriding-t-option");
+        }
+
         cc_build
     }
 

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -176,7 +176,6 @@ impl CmakeBuilder {
         // If the build environment vendor is Apple
         #[cfg(target_vendor = "apple")]
         {
-            cmake_cfg.cflag("-Wno-overriding-t-option");
             if target_arch() == "aarch64" {
                 cmake_cfg.define("CMAKE_OSX_ARCHITECTURES", "arm64");
                 cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "arm64");


### PR DESCRIPTION
### Issues:
Addresses:
* #602

### Description of changes: 
* Use of the `-Wno-overriding-t-option` causes build failure on certain platforms. Limit its use to the specific environments that it might be needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
