### PR TITLE
Warn unsupported compiler on FIPS build

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -64,6 +64,7 @@ cmake = "0.1.48"
 dunce = "1.0"
 fs_extra = "1.3"
 cc = "1.0.100"
+regex = "1"
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = "")))'.build-dependencies]
 bindgen = { version = "0.69.5", optional = true }

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -256,12 +256,8 @@ impl CmakeBuilder {
                             }
                         }
                         if compiler.is_like_clang() {
+                            // AWS-LC-FIPS 2.0 was unable to compile with Clang 19
                             emit_warning(&format!("Clang v{major}.{minor}.{patch} detected."));
-                            if major > 18 {
-                                // TODO: Update when FIPS Clang 19 build is fixed
-                                emit_warning("WARNING: FIPS build is known to fail on Clang >= 19. See: https://github.com/aws/aws-lc-rs/issues/569");
-                                return Some(false);
-                            }
                         }
                         return Some(true);
                     }
@@ -425,7 +421,7 @@ impl crate::Builder for CmakeBuilder {
 }
 
 fn parse_version(line: &str) -> Option<(u32, u32, u32)> {
-    let version_pattern = regex::Regex::new(r"\s(\d{1,2})\.(\d{1,2})\.(\d+)").unwrap();
+    let version_pattern = regex::Regex::new(r"\s(\d{1,2})\.(\d{1,2})\.(\d+)").ok()?;
     let captures = version_pattern.captures(line)?;
 
     let major_str = captures.get(1)?.as_str();

--- a/aws-lc-fips-sys/builder/main.rs
+++ b/aws-lc-fips-sys/builder/main.rs
@@ -216,9 +216,7 @@ fn target_platform_prefix(name: &str) -> String {
 }
 
 pub(crate) struct TestCommandResult {
-    #[allow(dead_code)]
     stderr: Box<str>,
-    #[allow(dead_code)]
     stdout: Box<str>,
     executed: bool,
     status: bool,

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -62,7 +62,7 @@ which = "5.0.0"
 # Pinned dependency to preserve MSRV: ??? <= rust-version < 1.70.0
 home = "=0.5.5"
 # Pinned dependency to preserve MSRV: 1.60.0  <= rust-version < 1.65.0
-regex = "~1.9.6"
+regex = "<1.10.0"
 # Pinned dependency to preserve MSRV: ??? <= rust-version < 1.65.0
 regex-automata = "~0.3.9"
 # Pinned dependency to preserve MSRV: 1.60.0  <= rust-version < 1.65.0


### PR DESCRIPTION
### Issues:
Addresses #569

### Description of changes: 
Provide warning to consumers when using an unsupported compiler for the FIPS build.

### Call-outs:
N/A

### Testing:
Manually tested on MacOS, Ubuntu and Windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
