### PR TITLE
Add ability to prepare the next operation and it's associated nonce for OpeningKey and SealingKey

### DIFF
--- a/aws-lc-rs/src/aead.rs
+++ b/aws-lc-rs/src/aead.rs
@@ -1032,6 +1032,6 @@ mod tests {
     #[test]
     fn debug_tag() {
         let tag = Tag([0u8; MAX_TAG_LEN], MAX_TAG_LEN);
-        assert_eq!("Tag", format!("{tag:?}"))
+        assert_eq!("Tag", format!("{tag:?}"));
     }
 }

--- a/aws-lc-rs/src/aead.rs
+++ b/aws-lc-rs/src/aead.rs
@@ -450,7 +450,7 @@ impl<N: NonceSequence> SealingKey<N> {
     }
 }
 
-macro_rules! nonce_sequence_key_iterator {
+macro_rules! key_op_mut {
     ($name:ident) => {
         paste! {
         /// A key operation with a precomputed nonce from a key's associated `NonceSequence`.
@@ -478,8 +478,8 @@ macro_rules! nonce_sequence_key_iterator {
     };
 }
 
-nonce_sequence_key_iterator!(OpeningKey);
-nonce_sequence_key_iterator!(SealingKey);
+key_op_mut!(OpeningKey);
+key_op_mut!(SealingKey);
 
 impl<N: NonceSequence> OpeningKeyOpMut<'_, N> {
     /// Returns the Nonce that will be used for this operation.

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -665,7 +665,7 @@ impl aead::NonceSequence for OneNonceSequence {
 }
 
 #[test]
-fn prepare_operation() {
+fn prepare_nonce() {
     const KEY: &[u8] = &[
         0x52, 0x05, 0x19, 0x7a, 0xcc, 0x88, 0xdb, 0x78, 0x39, 0x59, 0xbc, 0x03, 0xb8, 0x1d, 0x4a,
         0x6c,
@@ -688,10 +688,10 @@ fn prepare_operation() {
     let mut nonces: Vec<Vec<u8>> = vec![];
 
     for _ in 0..(LIMIT / 2) {
-        let so = sk.prepare_operation().unwrap();
-        let oo = ok.prepare_operation().unwrap();
-        let so_nonce = Vec::from(so.nonce().as_ref());
-        let oo_nonce = Vec::from(oo.nonce().as_ref());
+        let skpn = sk.prepare_nonce().unwrap();
+        let okpn = ok.prepare_nonce().unwrap();
+        let so_nonce = Vec::from(skpn.nonce().as_ref());
+        let oo_nonce = Vec::from(okpn.nonce().as_ref());
 
         assert_eq!(so_nonce.as_slice(), oo_nonce.as_slice());
         assert!(!nonces.contains(&so_nonce));
@@ -701,15 +701,15 @@ fn prepare_operation() {
         let mut message: Vec<u8> = vec![];
         message.extend_from_slice(MESSAGE);
 
-        so.seal_in_place_append_tag(Aad::empty(), &mut message)
+        skpn.seal_in_place_append_tag(Aad::empty(), &mut message)
             .unwrap();
         assert_ne!(MESSAGE, message.as_slice());
 
-        let message = oo.open_in_place(Aad::empty(), &mut message).unwrap();
+        let message = okpn.open_in_place(Aad::empty(), &mut message).unwrap();
         assert_eq!(MESSAGE, message);
 
-        let so = sk.prepare_operation().unwrap();
-        let oo = ok.prepare_operation().unwrap();
+        let so = sk.prepare_nonce().unwrap();
+        let oo = ok.prepare_nonce().unwrap();
         let so_nonce = Vec::from(so.nonce().as_ref());
         let oo_nonce = Vec::from(oo.nonce().as_ref());
 
@@ -741,8 +741,8 @@ fn prepare_operation() {
     message.extend_from_slice(MESSAGE);
 
     // Subsequent usage should fail now since the sequence is exhausted in each key.
-    sk.prepare_operation().expect_err("sequence limit reached");
-    ok.prepare_operation().expect_err("sequence limit reached");
+    sk.prepare_nonce().expect_err("sequence limit reached");
+    ok.prepare_nonce().expect_err("sequence limit reached");
     sk.seal_in_place_append_tag(Aad::empty(), &mut message)
         .expect_err("sequence limit reached");
     sk.seal_in_place_separate_tag(Aad::empty(), &mut message)


### PR DESCRIPTION
### Issues:
Addresses #570

### Description of changes: 
Provides the ability for a user to precompute the next operation's nonce value for `OpeningKey` and `SealingKey` types via `OpeningKey::prepare_operation` and `SealingKey::prepare_operation` which return `OpeningKeyOpMut` and `SealingKeyOpMut` respectively containing the nonce for the encapsulated operation. Each type provides a `nonce()` method by which the nonce can be retrieved by the caller prior to invoking each types respective opening and sealing operation which will use the nonce.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
