### PR TITLE
Fix i686-pc-windows-gnu external bindgen

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -183,9 +183,7 @@ jobs:
       matrix:
         target:
           - 'x86_64-pc-windows-gnu'
-          # TODO: Fails in GitHub CI.  Appears to be related to bindgen.
-          # .../base.h:61:10: fatal error: 'stdlib.h' file not found
-          # - 'i686-pc-windows-gnu'
+          - 'i686-pc-windows-gnu'
     steps:
       - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
@@ -196,6 +194,11 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target }}
+      - if: ${{ matrix.target == 'i686-pc-windows-gnu' }}
+        name: Install mingw
+        uses: bwoodsend/setup-winlibs-action@v1
+        with:
+          architecture: i686
       - name: Debug Test on `${{ matrix.target }}`
         run: cargo test -p aws-lc-rs --target ${{ matrix.target }} --features bindgen
       - name: Release test on `${{ matrix.target }}`

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -267,21 +267,19 @@ jobs:
 
   build-env-external-bindgen-test:
     if: github.repository_owner == 'aws'
-    name: aws-lc-rs FIPS - External bindgen test
+    name: aws-lc-rs - External bindgen test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     env:
       AWS_LC_SYS_EXTERNAL_BINDGEN: 1
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - uses: dtolnay/rust-toolchain@stable
-      - if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/setup-nasm@v1
       - name: Install bindgen-cli
         run: cargo install --locked bindgen-cli
       - name: Remove bindings
@@ -290,6 +288,39 @@ jobs:
           rm ./aws-lc-sys/src/aarch64*
       - name: Run cargo test
         run: cargo test --tests -p aws-lc-rs --no-default-features --features aws-lc-sys
+
+  build-env-external-bindgen-windows-test:
+    if: github.repository_owner == 'aws'
+    name: aws-lc-rs - External bindgen test (${{ matrix.target }})
+    runs-on: windows-latest
+    env:
+      AWS_LC_SYS_EXTERNAL_BINDGEN: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ 'i686-pc-windows-gnu', 'i686-pc-windows-msvc', 'x86_64-pc-windows-msvc', 'x86_64-pc-windows-gnu' ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.target }}
+      - uses: ilammy/setup-nasm@v1
+      - name: Install bindgen-cli
+        run: cargo install --locked bindgen-cli
+      - name: Remove bindings
+        run: |
+          rm ./aws-lc-sys/src/x86_64*
+          rm ./aws-lc-sys/src/aarch64*
+          rm ./aws-lc-sys/src/i686*
+      - if: ${{ matrix.target == 'i686-pc-windows-gnu' }}
+        name: Install mingw
+        uses: bwoodsend/setup-winlibs-action@v1
+        with:
+          architecture: i686
+      - name: Run cargo test
+        run: cargo test --tests -p aws-lc-rs --no-default-features --features aws-lc-sys --target ${{ matrix.target }}
 
   build-env-fips-static-test:
     if: github.repository_owner == 'aws'

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -760,7 +760,9 @@ fn invoke_external_bindgen(
     let sym_prefix: String;
     let mut bindgen_params = vec![];
     if let Some(prefix_str) = prefix {
-        sym_prefix = if target_os().to_lowercase() == "macos" || target_os().to_lowercase() == "ios"
+        sym_prefix = if target_os().to_lowercase() == "macos"
+            || target_os().to_lowercase() == "ios"
+            || (target_os().to_lowercase() == "windows" && target_arch() == "x86")
         {
             format!("_{prefix_str}_")
         } else {


### PR DESCRIPTION
### Issues:
Addresses #620

### Description of changes: 
* Fix external bindgen for `i686-pc-windows-gnu`
* Add/Fix CI tests for various Windows targets


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
