### PR TITLE
Improve bindgen-cli error handling

### DIFF
--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -707,6 +707,11 @@ fn verify_bindgen() -> Result<(), String> {
             See our User Guide for more information about bindgen:\
             https://aws.github.io/aws-lc-rs/index.html"
             );
+        } else {
+            eprintln!(
+                "bindgen-cli exited with an error status:\nSTDOUT: {}\n\nSTDERR: {}",
+                result.stdout, result.stderr
+            )
         }
         return Err("External bindgen command failed.".to_string());
     }
@@ -723,11 +728,11 @@ fn verify_bindgen() -> Result<(), String> {
         }
     }
     // We currently expect to support all bindgen versions >= 0.69.3
-    if major_version == 0 && (minor_version < 69 || (minor_version == 69 && patch_version < 3)) {
+    if major_version == 0 && (minor_version < 69 || (minor_version == 69 && patch_version < 5)) {
         eprintln!(
             "bindgen-cli was used. Detected version was: \
             {major_version}.{minor_version}.{patch_version} \n\
-        If this is not the latest version, consider upgrading : \
+        Consider upgrading : \
         `cargo install --force --locked bindgen-cli`\
         \n\
         See our User Guide for more information about bindgen:\

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -727,7 +727,7 @@ fn verify_bindgen() -> Result<(), String> {
             patch_version = version_parts[2].parse::<u32>().unwrap_or(0);
         }
     }
-    // We currently expect to support all bindgen versions >= 0.69.3
+    // We currently expect to support all bindgen versions >= 0.69.5
     if major_version == 0 && (minor_version < 69 || (minor_version == 69 && patch_version < 5)) {
         eprintln!(
             "bindgen-cli was used. Detected version was: \

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -699,7 +699,12 @@ impl Debug for BindingOptions {
 fn verify_bindgen() -> Result<(), String> {
     let result = execute_command("bindgen".as_ref(), &["--version".as_ref()]);
     if !result.status {
-        if !result.executed {
+        if result.executed {
+            eprintln!(
+                "bindgen-cli exited with an error status:\nSTDOUT: {}\n\nSTDERR: {}",
+                result.stdout, result.stderr
+            );
+        } else {
             eprintln!(
                 "Consider installing the bindgen-cli: \
             `cargo install --force --locked bindgen-cli`\
@@ -707,11 +712,6 @@ fn verify_bindgen() -> Result<(), String> {
             See our User Guide for more information about bindgen:\
             https://aws.github.io/aws-lc-rs/index.html"
             );
-        } else {
-            eprintln!(
-                "bindgen-cli exited with an error status:\nSTDOUT: {}\n\nSTDERR: {}",
-                result.stdout, result.stderr
-            )
         }
         return Err("External bindgen command failed.".to_string());
     }


### PR DESCRIPTION
### Issues:
Addresses #624

### Description of changes: 
Improve error handling when invocation of `bindgen-cli` fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
