### PR TITLE
Update nightly toolchain used for -Zscript

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -17,7 +17,7 @@ env:
   # We can pin the version if nightly is too unstable.
   # Otherwise, we test against the latest version.
   RUST_NIGHTLY_TOOLCHAIN: nightly
-  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly-2024-05-22
+  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly
 
 jobs:
   rustfmt:

--- a/.github/workflows/fips-bindings-generator.yml
+++ b/.github/workflows/fips-bindings-generator.yml
@@ -14,7 +14,7 @@ env:
   # We can pin the version if nightly is too unstable.
   # Otherwise, we test against the latest version.
   RUST_NIGHTLY_TOOLCHAIN: nightly
-  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly-2024-05-22
+  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/pregen-bindings.yml
+++ b/.github/workflows/pregen-bindings.yml
@@ -17,7 +17,7 @@ env:
   # We can pin the version if nightly is too unstable.
   # Otherwise, we test against the latest version.
   RUST_NIGHTLY_TOOLCHAIN: nightly
-  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly-2024-05-22
+  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly
   GOPROXY: https://proxy.golang.org,direct
 jobs:
   sys-bindings:

--- a/.github/workflows/sys-bindings-generator.yml
+++ b/.github/workflows/sys-bindings-generator.yml
@@ -14,7 +14,7 @@ env:
   # We can pin the version if nightly is too unstable.
   # Otherwise, we test against the latest version.
   RUST_NIGHTLY_TOOLCHAIN: nightly
-  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly-2024-05-22
+  RUST_SCRIPT_NIGHTLY_TOOLCHAIN: nightly
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/aws-lc-rs/util/process-criterion-csv.rs
+++ b/aws-lc-rs/util/process-criterion-csv.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S cargo +nightly-2024-05-22 -Zscript
+#!/usr/bin/env -S cargo +nightly -Zscript
 ---cargo
 [dependencies]
 clap = { version = "4.0.29", features = ["derive"] }

--- a/scripts/tools/cargo-dig.rs
+++ b/scripts/tools/cargo-dig.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S cargo +nightly-2024-05-22 -Zscript
+#!/usr/bin/env -S cargo +nightly -Zscript
 ---cargo
 [dependencies]
 toml = "0.8"

--- a/scripts/tools/semver.rs
+++ b/scripts/tools/semver.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S cargo +nightly-2024-05-22 -Zscript
+#!/usr/bin/env -S cargo +nightly -Zscript
 ---cargo
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/scripts/tools/target-platform.rs
+++ b/scripts/tools/target-platform.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S cargo +nightly-2024-05-22 -Zscript
+#!/usr/bin/env -S cargo +nightly -Zscript
 
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC


### PR DESCRIPTION
### Description of changes: 
There is no need to still tie our Rust scripts to the `nightly-2024-05-22` toolchain.

### Testing:
* Verified bindgen workflow still succeeds with this commit: https://github.com/aws/aws-lc-rs/actions/runs/12437445624

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
