### PR TITLE
Avoid appending empty path to artifact directory.

### DIFF
--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -60,10 +60,6 @@ fn find_cmake_command() -> Option<OsString> {
     }
 }
 
-fn get_platform_output_path() -> PathBuf {
-    PathBuf::new()
-}
-
 impl CmakeBuilder {
     pub(crate) fn new(
         manifest_dir: PathBuf,
@@ -80,10 +76,7 @@ impl CmakeBuilder {
     }
 
     fn artifact_output_dir(&self) -> PathBuf {
-        self.out_dir
-            .join("build")
-            .join("artifacts")
-            .join(get_platform_output_path())
+        self.out_dir.join("build").join("artifacts")
     }
 
     fn get_cmake_config(&self) -> cmake::Config {

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -60,9 +60,7 @@ impl CmakeBuilder {
     }
 
     fn artifact_output_dir(&self) -> PathBuf {
-        self.out_dir
-            .join("build")
-            .join("artifacts")
+        self.out_dir.join("build").join("artifacts")
     }
 
     fn get_cmake_config(&self) -> cmake::Config {

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -44,10 +44,6 @@ fn find_cmake_command() -> Option<OsString> {
     }
 }
 
-fn get_platform_output_path() -> PathBuf {
-    PathBuf::new()
-}
-
 impl CmakeBuilder {
     pub(crate) fn new(
         manifest_dir: PathBuf,
@@ -67,7 +63,6 @@ impl CmakeBuilder {
         self.out_dir
             .join("build")
             .join("artifacts")
-            .join(get_platform_output_path())
     }
 
     fn get_cmake_config(&self) -> cmake::Config {


### PR DESCRIPTION
### Issues:
Related to https://github.com/aws/aws-lc-rs/issues/571#issuecomment-2453515258

The build script for aws-lc-sys appends a library search path to the final linker command line. On Windows environments when building with lld-link.exe, the inclusion of an empty directory at the end of this path can cause a build failure.

The problematic path looks like this: `/LIBPATH:C:\\\\a\\\\servo\\\\servo\\\\target\\release\\build\\aws-lc-sys-d847be10163c7448\\out\\build\\artifacts\\`

The presence of the `\\` at the end of the path causes the subsequent character to be treated as an escaped character, leading to a failure to parse the linker argument that follows this.

### Description of changes:
Since the final component of the path is always empty, we can remove it without any behaviour change.

### Testing:
Verified this change by building Servo on Windows with my branch of aws-lc-sys. Before the change it failed to build; after the change it builds successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
