### PR TITLE
Improve message when repo submods not initialized

### DIFF
--- a/aws-lc-fips-sys/CMakeLists.txt
+++ b/aws-lc-fips-sys/CMakeLists.txt
@@ -22,6 +22,9 @@ if (BUILD_SHARED_LIBS AND FIPS)
 endif()
 
 add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
+if(NOT EXISTS aws-lc/CMakeLists.txt)
+message(WARNING "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? CMakeLists.txt not found.")
+endif()
 
 if (BUILD_LIBSSL)
     add_definitions(-DAWS_LC_RUST_INCLUDE_SSL)

--- a/aws-lc-fips-sys/CMakeLists.txt
+++ b/aws-lc-fips-sys/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
 if(NOT EXISTS aws-lc/CMakeLists.txt)
-message(WARNING "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? CMakeLists.txt not found.")
+message(WARNING "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? CMakeLists.txt not found.\n -- run 'git submodule update --init --recursive' to initialize.")
 endif()
 
 if (BUILD_LIBSSL)

--- a/aws-lc-sys/CMakeLists.txt
+++ b/aws-lc-sys/CMakeLists.txt
@@ -18,6 +18,9 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
+if(NOT EXISTS aws-lc/CMakeLists.txt)
+message(WARNING "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? CMakeLists.txt not found.")
+endif()
 
 if (BUILD_LIBSSL)
     add_definitions(-DAWS_LC_RUST_INCLUDE_SSL)

--- a/aws-lc-sys/CMakeLists.txt
+++ b/aws-lc-sys/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
 if(NOT EXISTS aws-lc/CMakeLists.txt)
-message(WARNING "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? CMakeLists.txt not found.")
+message(WARNING "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? CMakeLists.txt not found.\n -- run 'git submodule update --init --recursive' to initialize.")
 endif()
 
 if (BUILD_LIBSSL)

--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -267,14 +267,20 @@ impl CcBuilder {
         let mut ret_val = false;
         let output_dir = self.out_dir.join(format!("out-{basename}"));
         let mut cc_build = self.create_builder();
+        let source_file = self
+            .manifest_dir
+            .join("aws-lc")
+            .join("tests")
+            .join("compiler_features_tests")
+            .join(format!("{basename}.c"));
+        if !source_file.exists() {
+            emit_warning(&format!(
+                "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? Unable to find source file: {:?}.",
+                &source_file
+            ));
+        }
         cc_build
-            .file(
-                self.manifest_dir
-                    .join("aws-lc")
-                    .join("tests")
-                    .join("compiler_features_tests")
-                    .join(format!("{basename}.c")),
-            )
+            .file(source_file)
             .warnings_into_errors(true)
             .out_dir(&output_dir);
 

--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -274,10 +274,15 @@ impl CcBuilder {
             .join("compiler_features_tests")
             .join(format!("{basename}.c"));
         if !source_file.exists() {
+            emit_warning("######");
+            emit_warning("###### WARNING: MISSING GIT SUBMODULE ######");
             emit_warning(&format!(
-                "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? Unable to find source file: {:?}.",
+                "  -- Did you initialize the repo's git submodules? Unable to find source file: {:?}.",
                 &source_file
             ));
+            emit_warning("  -- run 'git submodule update --init --recursive' to initialize.");
+            emit_warning("######");
+            emit_warning("######");
         }
         cc_build
             .file(source_file)

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -597,6 +597,18 @@ fn main() {
             bindings_available = true;
         }
     } else if is_bindgen_required() {
+        let aws_lc_crypto_dir = Path::new(&manifest_dir).join("aws-lc").join("crypto");
+        if !aws_lc_crypto_dir.exists() {
+            emit_warning("######");
+            emit_warning("###### WARNING: MISSING GIT SUBMODULE ######");
+            emit_warning(&format!(
+                "  -- Did you initialize the repo's git submodules? Unable to find crypto directory: {:?}.",
+                &aws_lc_crypto_dir
+            ));
+            emit_warning("  -- run 'git submodule update --init --recursive' to initialize.");
+            emit_warning("######");
+            emit_warning("######");
+        }
         bindings_available = handle_bindgen(&manifest_dir, &prefix);
     } else {
         bindings_available = true;


### PR DESCRIPTION
### Description of changes: 
Improve messaging when a contributor clones our repo but doesn't initialize the submodules prior to a build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
