### PR TITLE
[DRAFT] Support FIPS build w/ CPU Jitter

### DIFF
--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -86,3 +86,22 @@ jobs:
       - name: Run cargo test
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }}
+  cpu-jitter-entropy-test:
+    if: github.repository_owner == 'aws'
+    name: CPU Jitter Entropy Tests
+    runs-on: ubuntu-latest
+    env:
+      AWS_LC_FIPS_SYS_CPU_JITTER_ENTROPY: 1
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: nightly
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+      - name: Run assert script
+        run: ./scripts/tests/assert_cpu_jitter_entropy.rs

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::OutputLib::{Crypto, RustWrapper, Ssl};
-use crate::{
-    cargo_env, emit_warning, execute_command, is_no_asm, option_env, target, target_arch,
-    target_env, target_family, target_os, target_underscored, target_vendor, OutputLibType,
-    TestCommandResult,
-};
+use crate::{cargo_env, emit_rustc_cfg, emit_warning, execute_command, is_cpu_jitter_entropy, is_no_asm, option_env, target, target_arch, target_env, target_family, target_os, target_underscored, target_vendor, OutputLibType, TestCommandResult};
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
@@ -97,6 +93,11 @@ impl CmakeBuilder {
             cmake_cfg.define("BUILD_SHARED_LIBS", "1");
         } else {
             cmake_cfg.define("BUILD_SHARED_LIBS", "0");
+        }
+
+        if is_cpu_jitter_entropy() {
+            cmake_cfg.define("ENABLE_FIPS_ENTROPY_CPU_JITTER", "ON");
+            emit_rustc_cfg("cpu_jitter_entropy");
         }
 
         let cc_build = cc::Build::new();

--- a/aws-lc-fips-sys/builder/main.rs
+++ b/aws-lc-fips-sys/builder/main.rs
@@ -346,6 +346,7 @@ static mut AWS_LC_FIPS_SYS_NO_PREFIX: bool = false;
 static mut AWS_LC_FIPS_SYS_PREGENERATING_BINDINGS: bool = false;
 static mut AWS_LC_FIPS_SYS_EXTERNAL_BINDGEN: bool = false;
 static mut AWS_LC_FIPS_SYS_NO_ASM: bool = false;
+static mut AWS_LC_FIPS_SYS_CPU_JITTER_ENTROPY: bool = false;
 fn initialize() {
     unsafe {
         AWS_LC_FIPS_SYS_NO_PREFIX = env_var_to_bool("AWS_LC_FIPS_SYS_NO_PREFIX").unwrap_or(false);
@@ -354,6 +355,8 @@ fn initialize() {
         AWS_LC_FIPS_SYS_EXTERNAL_BINDGEN =
             env_var_to_bool("AWS_LC_FIPS_SYS_EXTERNAL_BINDGEN").unwrap_or(false);
         AWS_LC_FIPS_SYS_NO_ASM = env_var_to_bool("AWS_LC_FIPS_SYS_NO_ASM").unwrap_or(false);
+        AWS_LC_FIPS_SYS_CPU_JITTER_ENTROPY =
+            env_var_to_bool("AWS_LC_FIPS_SYS_CPU_JITTER_ENTROPY").unwrap_or(false);
     }
 
     if !is_external_bindgen() && (is_pregenerating_bindings() || !has_bindgen_feature()) {
@@ -409,6 +412,10 @@ fn is_no_asm() -> bool {
     unsafe { AWS_LC_FIPS_SYS_NO_ASM }
 }
 
+fn is_cpu_jitter_entropy() -> bool {
+    unsafe { AWS_LC_FIPS_SYS_CPU_JITTER_ENTROPY }
+}
+
 fn has_bindgen_feature() -> bool {
     cfg!(feature = "bindgen")
 }
@@ -423,6 +430,7 @@ fn prepare_cargo_cfg() {
         println!("cargo:rustc-check-cfg=cfg(aarch64_apple_darwin)");
         println!("cargo:rustc-check-cfg=cfg(aarch64_unknown_linux_gnu)");
         println!("cargo:rustc-check-cfg=cfg(aarch64_unknown_linux_musl)");
+        println!("cargo:rustc-check-cfg=cfg(cpu_jitter_entropy)");
         println!("cargo:rustc-check-cfg=cfg(i686_unknown_linux_gnu)");
         println!("cargo:rustc-check-cfg=cfg(use_bindgen_generated)");
         println!("cargo:rustc-check-cfg=cfg(x86_64_apple_darwin)");

--- a/aws-lc-fips-sys/src/lib.rs
+++ b/aws-lc-fips-sys/src/lib.rs
@@ -84,6 +84,12 @@ pub fn ERR_GET_FUNC(packed_error: u32) -> i32 {
     unsafe { ERR_GET_FUNC_RUST(packed_error) }
 }
 
+#[allow(non_snake_case)]
+#[must_use]
+pub fn CFG_CPU_JITTER_ENTROPY() -> bool {
+    cfg!(cpu_jitter_entropy)
+}
+
 #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
 pub fn BIO_get_mem_data(b: *mut BIO, pp: *mut *mut c_char) -> c_long {
     unsafe { BIO_ctrl(b, BIO_CTRL_INFO, 0, pp.cast::<c_void>()) }

--- a/scripts/tests/assert_cpu_jitter_entropy.rs
+++ b/scripts/tests/assert_cpu_jitter_entropy.rs
@@ -1,0 +1,13 @@
+#!/usr/bin/env -S cargo +nightly -Zscript
+---cargo
+[dependencies]
+aws-lc-rs = { version = "1", path = "../../aws-lc-rs", default-features = false, features = ["fips"] }
+---
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+fn main()  {
+    println!("Checking for CPU Jitter Entropy");
+    aws_lc_rs::fips_cpu_jitter_entropy();
+    println!("CPU Jitter Entropy Success");
+}


### PR DESCRIPTION
### Issues:
Addresses: CryptoAlg-2814

### Description of changes: 
* Detects environment variable `AWS_LC_FIPS_SYS_CPU_JITTER_ENTROPY` indicating that AWS-LC should be built to use cpu jitter entropy.
* Adds functions to allow consumers to verify cpu jitter entropy is in use at runtime.

### Call-outs:
* The required `FIPS_is_entropy_cpu_jitter` function is not yet available on the FIPS branch.  So the check currently only verifies that the "cpu_jitter_entropy" configuration was successfully detected by the build scripts.
* This PR depends on: #649

### Testing:
* Added script/CI that verifies that the `fips_cpu_jitter_entropy()` assertion succeeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
